### PR TITLE
Update master.yaml from Feb to May 2017 configuration

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -16,8 +16,8 @@ Description: >
     Based on AWSLabs ECS Reference Arhitecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 13th May 2017
-    Author Dan Carr (ddcarr@gmail.com)
+    Last Modified: 13th May 2018
+    Author Dan Carr (ddcarr@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
 

--- a/master.yaml
+++ b/master.yaml
@@ -16,7 +16,7 @@ Description: >
     Based on AWSLabs ECS Reference Arhitecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 17th February 2017
+    Last Modified: 13th May 2017
     Author Dan Carr (ddcarr@gmail.com)
 
 Parameters:
@@ -161,7 +161,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
-                ConfigBucket: hacko-transport-config
+                ConfigBucket: hacko-transportation-config
                 DeployTarget: integration
                 ProjSettingsDir: transportationAPI
                 Path: /transport*


### PR DESCRIPTION
Found a more up to date version in our canonical S3 repo for ECS templates:
https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/master.yaml

And confirmed that this one change is current with the naming of the bucket used for that configuration.