### PR TITLE
Update Transport's service.yaml from the S3 version that was committed in May 2017

### DIFF
--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -60,7 +60,7 @@ Resources:
                 - Name: transport-service
                   Essential: true
                   Image: 845828040396.dkr.ecr.us-west-2.amazonaws.com/integration/transport-service:latest
-                  Memory: 100
+                  Memory: 2048
                   Environment:
                     - Name: CONFIG_BUCKET
                       Value: !Ref ConfigBucket


### PR DESCRIPTION
Found a more up to date version in our canonical S3 repo for ECS templates:
https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/services/transport-service/service.yaml

And I'm here to confirm that this change is consistent with the memory issues we'd experienced throughout last season with Transportation's API, and I recall having made a change like this, so I'll trust this is current with production.