### PR TITLE
update InstanceType in master.yaml to reflect production not testing value

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -64,7 +64,7 @@ Resources:
             Parameters:
                 EnvironmentName: !Ref AWS::StackName
                 KeyPairName: !Ref KeyPairName
-                InstanceType: t2.micro
+                InstanceType: t2.large
                 ClusterSize: 2
                 VPC: !GetAtt VPC.Outputs.VPC
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSHostSecurityGroup


### PR DESCRIPTION
Production for these VM's is definitely at `t2.large`.

I will assume the `t2.micro` was never updated after testing of this infrastructure was completed.