### PR TITLE
Remove the orphaned Parameters

### DIFF
--- a/services/civic-2017-service/service.yaml
+++ b/services/civic-2017-service/service.yaml
@@ -19,18 +19,6 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
-    ConfigBucket:
-        Description: The configuration bucket we want to use
-        Type: String
-
-    DeployTarget:
-        Description: Which environment (Valid Values - integration, production)
-        Type: String
-
-    ProjSettingsDir:
-        Description: the relative directory path where we keep the app config
-        Type: String
-
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String

--- a/services/civic-2018-service/service.yaml
+++ b/services/civic-2018-service/service.yaml
@@ -18,18 +18,6 @@
             "Description": "The Application Load Balancer listener to register with",
             "Type": "String"
         },
-        "ConfigBucket": {
-            "Description": "The configuration bucket we want to use",
-            "Type": "String"
-        },
-        "DeployTarget": {
-            "Description": "Which environment (Valid Values - integration, production)",
-            "Type": "String"
-        },
-        "ProjSettingsDir": {
-            "Description": "the relative directory path where we keep the app config",
-            "Type": "String"
-        },
         "Host": {
             "Description": "The host path to register with the Application Load Balancer",
             "Type": "String",


### PR DESCRIPTION
missed removing the Parameters from the header block of the service.yaml when we removed the env vars in PR 11