### PR TITLE
Issue 104

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -16,7 +16,7 @@ Description: >
     Based on AWSLabs ECS Reference Arhitecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 16th May 2018
+    Last Modified: 18th May 2018
     Author Dan Carr (ddcarr@gmail.com), Mike Lonergan (mikethecanuck@gmail.com), Ian Turner (iant18150@gmail.com)
 
 Parameters:
@@ -190,6 +190,18 @@ Resources:
                Host: staging-2018.civicpdx.org 
                Path: /*
 
+    Transportation-systemsService:
+       Type: AWS::CloudFormation::Stack
+       Properties:
+           TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/services/transportation-systems-service/service.yaml
+           Parameters:
+               VPC: !GetAtt VPC.Outputs.VPC
+               Cluster: !GetAtt ECS.Outputs.Cluster
+               DesiredCount: 2
+               Listener: !GetAtt ALB.Outputs.Listener
+               Host: staging-2018.civicpdx.org 
+               Path: /transportation-systems
+
 
 # New Services placed above this line
 
@@ -257,6 +269,6 @@ Outputs:
         Description: The URL endpoint for the civic2017 service
         Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "2017" ]]
 
-    Civic2018ServiceUrl:
-        Description: The URL endpoint for the civic2018 service
-        Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "2018" ]]
+    Transportation-systemsServiceUrl:
+        Description: The URL endpoint for the 2018 transportation-systems service
+        Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "/transportation-systems" ]]

--- a/master.yaml
+++ b/master.yaml
@@ -269,6 +269,10 @@ Outputs:
         Description: The URL endpoint for the civic2017 service
         Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "2017" ]]
 
+    Civic2018ServiceUrl:
+        Description: The URL endpoint for the civic2018 service
+        Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "2018" ]]
+
     Transportation-systemsServiceUrl:
         Description: The URL endpoint for the 2018 transportation-systems service
         Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "/transportation-systems" ]]

--- a/services/transportation-systems-service/service.yaml
+++ b/services/transportation-systems-service/service.yaml
@@ -55,7 +55,7 @@ Resources:
                 - Name: transportation-systems-service
                   Essential: true
                   Image: 845828040396.dkr.ecr.us-west-2.amazonaws.com/production/transportation-systems-service:latest
-                  Memory: 100
+                  Memory: 2048
                   PortMappings:
                     - ContainerPort: 3000
                   LogConfiguration:

--- a/services/transportation-systems-service/service.yaml
+++ b/services/transportation-systems-service/service.yaml
@@ -1,0 +1,141 @@
+Description: >
+    ECS Service - HackOregon 2018 transport-systems API
+    Last Modified: 18th May 2018
+    Author Ian Turner (iant18150@gmail.com)
+
+Parameters:
+
+    VPC:
+        Description: The VPC that the ECS cluster is deployed to
+        Type: AWS::EC2::VPC::Id
+
+    Cluster:
+        Description: Please provide the ECS Cluster ID that this service should run on
+        Type: String
+
+    DesiredCount:
+        Description: How many instances of this task should we run across our cluster?
+        Type: Number
+        Default: 2
+
+    Listener:
+        Description: The Application Load Balancer listener to register with
+        Type: String
+
+    Host:
+        Description: The host path to register with the Application Load Balancer
+        Type: String
+        Default: staging-2018.civicpdx.org
+
+    Path:
+        Description: The path to register with the Application Load Balancer
+        Type: String
+        Default: /transport-sysytems
+
+Resources:
+
+    Service:
+        Type: AWS::ECS::Service
+        DependsOn: ListenerRule
+        Properties:
+            Cluster: !Ref Cluster
+            Role: !Ref ServiceRole
+            DesiredCount: !Ref DesiredCount
+            TaskDefinition: !Ref TaskDefinition
+            LoadBalancers:
+                - ContainerName: "transportation-systems-service"
+                  ContainerPort: 3000
+                  TargetGroupArn: !Ref TargetGroup
+
+    TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+            Family: transportation-systems-service
+            ContainerDefinitions:
+                - Name: transportation-systems-service
+                  Essential: true
+                  Image: 845828040396.dkr.ecr.us-west-2.amazonaws.com/production/transportation-systems-service:latest
+                  Memory: 100
+                  PortMappings:
+                    - ContainerPort: 3000
+                  LogConfiguration:
+                    LogDriver: awslogs
+                    Options:
+                        awslogs-group: !Ref AWS::StackName
+                        awslogs-region: !Ref AWS::Region
+
+    CloudWatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Ref AWS::StackName
+            RetentionInDays: 365
+
+    TargetGroup:
+        Type: AWS::ElasticLoadBalancingV2::TargetGroup
+        Properties:
+            VpcId: !Ref VPC
+            Port: 80
+            Protocol: HTTP
+            Matcher:
+                HttpCode: 200-299
+            HealthCheckIntervalSeconds: 45
+            HealthCheckPath: /transportation-systems
+            HealthCheckProtocol: HTTP
+            HealthCheckTimeoutSeconds: 40
+            HealthyThresholdCount: 4
+            UnhealthyThresholdCount: 5
+
+    ListenerRule:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref Listener
+            Priority: 40
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+ 
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    # This IAM Role grants the service access to register/unregister with the
+    # Application Load Balancer (ALB). It is based on the default documented here:
+    # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
+    ServiceRole:
+        Type: AWS::IAM::Role
+        Properties:
+            RoleName: !Sub ecs-service-${AWS::StackName}
+            Path: /
+            AssumeRolePolicyDocument: |
+                {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": { "Service": [ "ecs.amazonaws.com" ]},
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                }
+            Policies:
+                - PolicyName: !Sub ecs-service-${AWS::StackName}
+                  PolicyDocument:
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ec2:AuthorizeSecurityGroupIngress",
+                                    "ec2:Describe*",
+                                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                                    "elasticloadbalancing:Describe*",
+                                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                                    "elasticloadbalancing:DeregisterTargets",
+                                    "elasticloadbalancing:DescribeTargetGroups",
+                                    "elasticloadbalancing:DescribeTargetHealth",
+                                    "elasticloadbalancing:RegisterTargets"
+                                ],
+                                "Resource": "*"
+                        }]
+                    }


### PR DESCRIPTION
changes needed to master.yaml to add transportation-systems service and service.yaml file to define task definition and load balancer listener rule for service.

Right now, the following items have arbitrarily set values:
Host: staging-2018.civicpdx.org
Path: /transportation-systems
Port:3000
Priority: 40  (needs to be before the civic-2018 service and the civic-lab service)
Memory: 2048  2GB (last years service was a memory pig, hopefully this years will be less, setting high to start)
