### PR TITLE
Welcome TS and DR to the family

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -197,7 +197,7 @@ Resources:
            Parameters:
                VPC: !GetAtt VPC.Outputs.VPC
                Cluster: !GetAtt ECS.Outputs.Cluster
-               DesiredCount: 2
+               DesiredCount: 0
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org 
                Path: /local-elections
@@ -209,7 +209,7 @@ Resources:
            Parameters:
                VPC: !GetAtt VPC.Outputs.VPC
                Cluster: !GetAtt ECS.Outputs.Cluster
-               DesiredCount: 2
+               DesiredCount: 0
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org 
                Path: /neighborhood-development
@@ -221,7 +221,7 @@ Resources:
            Parameters:
                VPC: !GetAtt VPC.Outputs.VPC
                Cluster: !GetAtt ECS.Outputs.Cluster
-               DesiredCount: 2
+               DesiredCount: 0
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org
                Path: /housing-affordability


### PR DESCRIPTION
Now that DR and TS are deploying containers that survive the docker start, we need to make them permanently welcome - but leave the other 3 API services turned off until they start deploying