### PR TITLE
Fixing routing for ALB to reach the DR container

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -236,7 +236,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org
-               Path: /disaster-resilience
+               Path: /disaster-resilience*
 
     2018TS:
        Type: AWS::CloudFormation::Stack

--- a/services/disaster-resilience-service/service.yaml
+++ b/services/disaster-resilience-service/service.yaml
@@ -79,7 +79,7 @@ Resources:
             Matcher:
                 HttpCode: 200-299
             HealthCheckIntervalSeconds: 45
-            HealthCheckPath: /disaster-resilience
+            HealthCheckPath: /disaster-resilience/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40
             HealthyThresholdCount: 4


### PR DESCRIPTION
This follows the pattern established for last year's API containers, which appear to be still working