### PR TITLE
Fix routing for remaining services

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -200,7 +200,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org 
-               Path: /local-elections
+               Path: /local-elections*
 
     2018ND:
        Type: AWS::CloudFormation::Stack
@@ -212,7 +212,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org 
-               Path: /neighborhood-development
+               Path: /neighborhood-development*
 
     2018HA:
        Type: AWS::CloudFormation::Stack
@@ -224,7 +224,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org
-               Path: /housing-affordability
+               Path: /housing-affordability*
 
     2018DR:
        Type: AWS::CloudFormation::Stack
@@ -248,7 +248,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: service.civicpdx.org
-               Path: /transportation-systems
+               Path: /transportation-systems*
 
 # New Services placed above this line
 

--- a/services/housing-affordability-service/service.yaml
+++ b/services/housing-affordability-service/service.yaml
@@ -79,7 +79,7 @@ Resources:
             Matcher:
                 HttpCode: 200-299
             HealthCheckIntervalSeconds: 45
-            HealthCheckPath: /housing-affordability
+            HealthCheckPath: /housing-affordability/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40
             HealthyThresholdCount: 4

--- a/services/local-elections-service/service.yaml
+++ b/services/local-elections-service/service.yaml
@@ -79,7 +79,7 @@ Resources:
             Matcher:
                 HttpCode: 200-299
             HealthCheckIntervalSeconds: 45
-            HealthCheckPath: /local-elections
+            HealthCheckPath: /local-elections/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40
             HealthyThresholdCount: 4

--- a/services/neighborhood-development-service/service.yaml
+++ b/services/neighborhood-development-service/service.yaml
@@ -79,7 +79,7 @@ Resources:
             Matcher:
                 HttpCode: 200-299
             HealthCheckIntervalSeconds: 45
-            HealthCheckPath: /neighborhood-development
+            HealthCheckPath: /neighborhood-development/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40
             HealthyThresholdCount: 4

--- a/services/transportation-systems-service/service.yaml
+++ b/services/transportation-systems-service/service.yaml
@@ -79,7 +79,7 @@ Resources:
             Matcher:
                 HttpCode: 200-299
             HealthCheckIntervalSeconds: 45
-            HealthCheckPath: /transportation-systems
+            HealthCheckPath: /transportation-systems/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40
             HealthyThresholdCount: 4


### PR DESCRIPTION
fixing routing for the remaining 2018 containers since PR #29 appears to have fixed the problem for DR