### PR TITLE
Change ECS AMI to latest version (ami-d2f489aa)

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -47,6 +47,9 @@ Mappings:
     # You can find the latest available on this page of our documentation:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
     # (note the AMI identifier is region specific)
+    #
+    # Once AMI is upgraded to new version, can remove this mapping code and implement
+    # getting ECS latest AMI from the AWS made available Parameter Store location
 
     AWSRegionToAMI:
         us-east-1:
@@ -56,7 +59,7 @@ Mappings:
         us-west-1:
             AMI: ami-dd104dbd
         us-west-2:
-            AMI: ami-022b9262
+            AMI: ami-d2f489aa
         eu-west-1:
             AMI: ami-a7f2acc1
         eu-central-1:


### PR DESCRIPTION
needs to occur to get to latest ECS agent and docker versions. Also needed before can setup to auto get latest AMI from parameter store.

May need to manually balance tasks on instances after autoscaler updates the ecs instances. (may take 15 minutes for things to settle down after the upgrade.)