### PR TITLE
Added ecs volume settings

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -107,6 +107,11 @@ Resources:
             KeyName: !Ref KeyPairName
             SecurityGroups:
                 - !Ref SecurityGroup
+            BlockDeviceMappings:
+            - DeviceName: /dev/xvdcz
+              Ebs:
+                VolumeSize: 22
+                VolumeType: gp2
             IamInstanceProfile: !Ref ECSInstanceProfile
             UserData:
                 "Fn::Base64": !Sub |


### PR DESCRIPTION
So that the volume size can be easily changed from the
default 22GB.

Left setting at default value, may want to increase before merging if ecs instances are using close to to using the full 22 GB volume space.