### PR TITLE
Add another load balancer rule to the Civic2018 service

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -188,6 +188,7 @@ Resources:
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
                Host: staging-2018.civicpdx.org
+               Host2: civicplatform.org
                Path: /*
 
     2018LE:
@@ -199,7 +200,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
-               Host: service.civicpdx.org 
+               Host: service.civicpdx.org
                Path: /local-elections*
 
     2018ND:
@@ -211,7 +212,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
-               Host: service.civicpdx.org 
+               Host: service.civicpdx.org
                Path: /neighborhood-development*
 
     2018HA:
@@ -323,7 +324,7 @@ Outputs:
     2018LEServiceUrl:
         Description: The URL endpoint for the 2018 local-elections service
         Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "local-elections" ]]
-        
+
     2018NDServiceUrl:
         Description: The URL endpoint for the 2018 neighborhood-development service
         Value: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "neighborhood-development" ]]

--- a/services/civic-2018-service/service.yaml
+++ b/services/civic-2018-service/service.yaml
@@ -113,7 +113,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 46
+            Priority: 47
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/civic-2018-service/service.yaml
+++ b/services/civic-2018-service/service.yaml
@@ -24,6 +24,11 @@ Parameters:
         Type: String
         Default: staging-2018.civicpdx.org
 
+    Host2:
+        Description: Alias host to register with the Application Load Balancer
+        Type: String
+        Default: civicplatform.org
+
     Path:
         Description: The path to register with the Application Load Balancer
         Type: String
@@ -100,7 +105,19 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
- 
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRule2:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref Listener
+            Priority: 46
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host2
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward


### PR DESCRIPTION
This LB rule is to route traffic from civicplatform.org to this container.

This rule has already been added by hand and confirmed to do what is desired. This CF change has not been applied to the corresponding stack.