### PR TITLE
Add memory to local-elections container

### DIFF
--- a/services/local-elections-service/service.yaml
+++ b/services/local-elections-service/service.yaml
@@ -63,7 +63,7 @@ Resources:
                 - Name: local-elections-service
                   Essential: true
                   Image: 845828040396.dkr.ecr.us-west-2.amazonaws.com/production/local-elections:latest
-                  Memory: 300
+                  Memory: 400
                   PortMappings:
                     - ContainerPort: 8000
                   LogConfiguration:


### PR DESCRIPTION
Checked tonight, saw that `local-elections-service` was running in both EC2 hosts with 99% memory consumption:

```
$docker ps --format "{{.Names}}"  |  xargs docker stats  $1

CONTAINER ID        NAME                                                                                            CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
cae544aa64b2        ecs-local-elections-service-36-local-elections-service-aabecdae87dbd2af0300                     4.14%               298.2MiB / 300MiB     99.40%              70.3MB / 1.63GB     11.7TB / 3.77MB     0
```
