### PR TITLE
removing staging-2018.civicpdx.org

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -189,8 +189,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
-               Host: staging-2018.civicpdx.org
-               Host2: civicplatform.org
+               Host: civicplatform.org
                Path: /*
 
     2018LE:

--- a/services/civic-2018-service/service.yaml
+++ b/services/civic-2018-service/service.yaml
@@ -22,11 +22,6 @@ Parameters:
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
-        Default: staging-2018.civicpdx.org
-
-    Host2:
-        Description: Alias host to register with the Application Load Balancer
-        Type: String
         Default: civicplatform.org
 
     Path:
@@ -108,19 +103,6 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
-            Actions:
-                - TargetGroupArn: !Ref TargetGroup
-                  Type: forward
-
-    ListenerRule2:
-        Type: AWS::ElasticLoadBalancingV2::ListenerRule
-        Properties:
-            ListenerArn: !Ref Listener
-            Priority: 47
-            Conditions:
-                - Field: host-header
-                  Values:
-                    - !Ref Host2
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward


### PR DESCRIPTION
That URL is no longer required, post launch of the civicplatform.org identity.