### PR TITLE
Add explicit subdomain Host Header to service.civicpdx.org/budget

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -82,6 +82,7 @@ Resources:
                 ConfigBucket: hacko-budget-config
                 DeployTarget: integration
                 ProjSettingsDir: budget_proj
+                Host: service.civicpdx.org
                 Path: /budget*
 
     CivicLabService:

--- a/services/budget-service/service.yaml
+++ b/services/budget-service/service.yaml
@@ -1,5 +1,8 @@
 Description: >
     ECS Service - HackOregon Budget API
+    Last Modified: 1st July 2018
+    By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
+
 Parameters:
 
     VPC:
@@ -30,6 +33,11 @@ Parameters:
     ProjSettingsDir:
         Description: the relative directory path where we keep the app config
         Type: String
+
+    Host:
+        Description: The host path to register with the Application Load Balancer
+        Type: String
+        Default: service.civicpdx.org
 
     Path:
         Description: The path to register with the Application Load Balancer
@@ -109,8 +117,11 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 69
+            Priority: 8
             Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
                 - Field: path-pattern
                   Values:
                     - !Ref Path


### PR DESCRIPTION
This is a test of the pattern in PR #22, since I had to do something extra to get PR #44 to work under a different scenario.