### PR TITLE
Publish bare-bones list of 2017-2018 APIs

### DIFF
--- a/services/civic-lab-service/src/index.html
+++ b/services/civic-lab-service/src/index.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html>
 <title>The Civic Lab Front End Placeholder</title>
+<meta http-equiv="refresh" content="0; url=/endpoints/" />
 <xmp theme="united" style="display:none;">
-
-### Civic Lab Front End
-
-* This where the "landing page" will be. Go out and get your service deployed
-
 </xmp>
 <script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+<body>
+    <p><a href="http://service.civicpdx.org/endpoints/">Redirect</a></p>
+</body>
 </html>

--- a/services/endpoint-service/src/index.html
+++ b/services/endpoint-service/src/index.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
 <html>
-<title>HackOregon Service Endpoints</title>
+<title>HackOregon API Endpoints</title>
 <xmp theme="united" style="display:none;">
 
-### CivicLab Team
+  ### 2018 APIs
 
-  * [Civiclab](/)
+  * [The 2018 Disaster Resilience Service](/disaster-resilience/)([source](https://github.com/hackoregon/disaster-resilience-backend))
 
-### Budget Team
+  * [The 2018 Housing Affordability Service](/housing-affordability/)([source](https://github.com/hackoregon/housing-2018))
+  
+  * [The 2018 Local Elections Service](/local-elections/)([source](https://github.com/hackoregon/elections-2018-backend))
+  
+  * [The 2018 Neighborhood Development Service](/neighborhood-development/)([source](https://github.com/hackoregon/neighborhoods-2018))
+  
+  * [The 2018 Transportation Systems Service](/transportation-systems/)([source](https://github.com/hackoregon/transportation-systems-backend-2018))
 
-* [The Budget Service](/budget/)
+  ### 2017 APIs
 
-### Homelessness Team
+* [The 2017 Budget Service](/budget/)([source](https://github.com/hackoregon/team-budget))
 
-* [The Homelessness Service](/homeless/)
+* [The 2017 Emergency Response Service](/emergency/)([source](https://github.com/hackoregon/emergency-response-backend))
 
-### Housing Team
+* [The 2017 Homelessness Service](/homeless/)([source](https://github.com/hackoregon/teamhomelessness))
 
-* [The Housing Service](/housing/)
+* [The 2017 Housing Service](/housing/)([source](https://github.com/hackoregon/housing-backend))
 
-### Transportation Team
-
-* [The Transportation Service](/transport/)
-
-### Emergency Response Team
-
-* [The Emergency Response Service](/emergency/)
+* [The 2017 Transportation Service](/transport/)([source](https://github.com/hackoregon/transportation-backend))
 
 </xmp>
 <script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>


### PR DESCRIPTION
I fully expect that we will generate a branding-compliant container from the civic repo to take over this content, so this is just a straw man to get the ball rolling.

And since we have no use for the civic-lab-service's unformed "homepage" (since that identity/brand was never followed through), let's just redirect users to the API directory at /endpoints/ route.

Eventually someone will create a branding-compliant API directory page.