### PR TITLE
Add 443/HTTPS Listener to an ECS Stack via CloudFormation templates

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -62,8 +62,8 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::Listener
         Properties:
             Certificates:
-                # - CertificateArn: !Ref PublicAlbAcmCertificate
-                - CertificateArn: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
+                - CertificateArn: !Ref PublicAlbAcmCertificate
+                # - CertificateArn: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
             LoadBalancerArn: !Ref LoadBalancer
             Port: 443
             Protocol: HTTPS

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -22,6 +22,18 @@ Parameters:
         Description: Select the Security Group to apply to the Applicaion Load Balancer
         Type: AWS::EC2::SecurityGroup::Id
 
+    PublicAlbAcmCertificate:
+        AllowedPattern: ^$|(arn:aws:acm:)([a-z0-9/:-])*([a-z0-9])$
+        Description: '[ Optional ] The AWS Certification Manager certificate ARN for the ALB certificate - this certificate should be created in the region you wish to run the ALB and must reference the domain name you use below.'
+        Type: String
+
+Conditions:
+
+    SslCertificate:
+        !Not [!Equals [ '', !Ref PublicAlbAcmCertificate ] ]
+    NoSslCertificate:
+        !Equals [ '', !Ref PublicAlbAcmCertificate ]
+
 Resources:
 
     LoadBalancer:
@@ -46,8 +58,11 @@ Resources:
                   TargetGroupArn: !Ref DefaultTargetGroup
 
     LoadBalancerListenerTls:
+        Condition: SslCertificate
         Type: AWS::ElasticLoadBalancingV2::Listener
         Properties:
+            Certificates:
+            - CertificateArn: !Ref PublicAlbAcmCertificate
             LoadBalancerArn: !Ref LoadBalancer
             Port: 443
             Protocol: HTTPS
@@ -79,3 +94,13 @@ Outputs:
     Listener:
         Description: A reference to a port 80 listener
         Value: !Ref LoadBalancerListener
+
+    PublicAlbDnsName:
+        Value:
+            !GetAtt LoadBalancer.DNSName
+    PublicAlbHostname:
+        Value:
+            !If [ NoSslCertificate, !Join [ '', [ 'http://', !GetAtt LoadBalancer.DNSName ] ], !Join [ '', [ 'https://', !GetAtt LoadBalancer.DNSName ] ] ]
+    SslCertificate:
+        Value:
+            !If [ SslCertificate, True, False ]

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -1,6 +1,8 @@
 Description: >
     This template deploys an Application Load Balancer that exposes our various ECS services.
     We create them it a seperate nested template, so it can be referenced by all of the other nested templates.
+    Last Modified: 12 July 2018
+    By Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
 
@@ -39,6 +41,16 @@ Resources:
             LoadBalancerArn: !Ref LoadBalancer
             Port: 80
             Protocol: HTTP
+            DefaultActions:
+                - Type: forward
+                  TargetGroupArn: !Ref DefaultTargetGroup
+
+    LoadBalancerListenerTls:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+            LoadBalancerArn: !Ref LoadBalancer
+            Port: 443
+            Protocol: HTTPS
             DefaultActions:
                 - Type: forward
                   TargetGroupArn: !Ref DefaultTargetGroup

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -62,7 +62,8 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::Listener
         Properties:
             Certificates:
-            - CertificateArn: !Ref PublicAlbAcmCertificate
+                # - CertificateArn: !Ref PublicAlbAcmCertificate
+                - CertificateArn: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
             LoadBalancerArn: !Ref LoadBalancer
             Port: 443
             Protocol: HTTPS

--- a/master.yaml
+++ b/master.yaml
@@ -14,7 +14,7 @@ Description: >
     Based on AWSLabs ECS Reference Arhitecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 13 July 2018
+    Last Modified: 15 July 2018
     Author Dan Carr (ddcarr@gmail.com), Mike Lonergan (mikethecanuck@gmail.com), Ian Turner (iant18150@gmail.com)
 
 Parameters:
@@ -62,7 +62,6 @@ Resources:
                 Subnets: !GetAtt VPC.Outputs.PublicSubnets
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.LoadBalancerSecurityGroup
                 PublicAlbAcmCertificate: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
-                    # !Ref PublicAlbAcmCertificate
 
     ECS:
         Type: AWS::CloudFormation::Stack

--- a/master.yaml
+++ b/master.yaml
@@ -61,8 +61,8 @@ Resources:
                 VPC: !GetAtt VPC.Outputs.VPC
                 Subnets: !GetAtt VPC.Outputs.PublicSubnets
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.LoadBalancerSecurityGroup
-                PublicAlbAcmCertificate:
-                    !Ref PublicAlbAcmCertificate
+                PublicAlbAcmCertificate: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
+                    # !Ref PublicAlbAcmCertificate
 
     ECS:
         Type: AWS::CloudFormation::Stack

--- a/master.yaml
+++ b/master.yaml
@@ -14,13 +14,18 @@ Description: >
     Based on AWSLabs ECS Reference Arhitecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 08 July 2018
+    Last Modified: 13 July 2018
     Author Dan Carr (ddcarr@gmail.com), Mike Lonergan (mikethecanuck@gmail.com), Ian Turner (iant18150@gmail.com)
 
 Parameters:
 
     KeyPairName:
         Description: Key Pair for access to bastion and ecs host instances
+        Type: String
+
+    PublicAlbAcmCertificate:
+        AllowedPattern: ^$|(arn:aws:acm:)([a-z0-9/:-])*([a-z0-9])$
+        Description: '[ Optional ] The AWS Certification Manager certificate ARN for the ALB certificate - this certificate should be created in the region you wish to run the ALB and must reference the Drupal domain name you use below.'
         Type: String
 
 Resources:
@@ -56,6 +61,8 @@ Resources:
                 VPC: !GetAtt VPC.Outputs.VPC
                 Subnets: !GetAtt VPC.Outputs.PublicSubnets
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.LoadBalancerSecurityGroup
+                PublicAlbAcmCertificate:
+                    !Ref PublicAlbAcmCertificate
 
     ECS:
         Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Per [Civic-devops 170](https://github.com/hackoregon/civic-devops/issues/170) we need to enable TLS/HTTPS connectivity for service.civicpdx.org.

This is not yet completed, and is untested, so not worth merging yet.