### PR TITLE
Bind 443 listener to endpoint-service

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -96,6 +96,10 @@ Outputs:
         Description: A reference to a port 80 listener
         Value: !Ref LoadBalancerListener
 
+    ListenerTls:
+        Description: A reference to a port 443 listener
+        Value: !Ref LoadBalancerListenerTls
+
     PublicAlbDnsName:
         Value:
             !GetAtt LoadBalancer.DNSName

--- a/master.yaml
+++ b/master.yaml
@@ -223,6 +223,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ALB: !GetAtt ALB.Outputs.LoadBalancerUrl
                 Host: service.civicpdx.org
                 Path: /

--- a/services/endpoint-service/service.yaml
+++ b/services/endpoint-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     Web service to display the catalog of team services
-    Last Modified: 08 July 2018
+    Last Modified: 15 July 2018
     By Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -24,6 +24,10 @@ Parameters:
 
     Listener:
         Description: The Application Load Balancer listener to register with
+        Type: String
+    
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
         Type: String
     
     Host:
@@ -104,7 +108,23 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 4
+            Priority: 79
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRule:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 80
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/endpoint-service/service.yaml
+++ b/services/endpoint-service/service.yaml
@@ -116,6 +116,23 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    # Since the listener rule only applies strictly to / and the project has static assets,
+    # /__assets also needs to be routed into this container
+    ListenerRuleAssets:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref Listener
+            Priority: 80
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
                     - /__assets*
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
@@ -125,7 +142,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 80
+            Priority: 81
             Conditions:
                 - Field: host-header
                   Values:
@@ -133,6 +150,23 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    # Since the listener rule only applies strictly to / and the project has static assets,
+    # /__assets also needs to be routed into this container
+    ListenerRuleTlsAssets:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 82
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
                     - /__assets*
             Actions:
                 - TargetGroupArn: !Ref TargetGroup

--- a/services/endpoint-service/service.yaml
+++ b/services/endpoint-service/service.yaml
@@ -25,11 +25,11 @@ Parameters:
     Listener:
         Description: The Application Load Balancer listener to register with
         Type: String
-    
+
     ListenerTls:
         Description: The 443 Application Load Balancer listener to register with
         Type: String
-    
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -103,7 +103,7 @@ Resources:
             HealthCheckTimeoutSeconds: 30
             HealthyThresholdCount: 5
             UnhealthyThresholdCount: 5
-            
+
     ListenerRule:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
@@ -116,6 +116,7 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
+                    - /__assets*
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward
@@ -132,6 +133,7 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
+                    - /__assets*
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/endpoint-service/service.yaml
+++ b/services/endpoint-service/service.yaml
@@ -121,7 +121,7 @@ Resources:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward
 
-    ListenerRule:
+    ListenerRuleTls:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls


### PR DESCRIPTION
Goal: create separate `ListenerRule`s to enable ALB to route the following URLs both to the `endpoint-service` containerized NGINX app:
http://service.civicpdx.org/
https://service.civicpdx.org/