### PR TITLE
Add 443 listeners to 2018 APIs

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -131,6 +131,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: service.civicpdx.org
                Path: /local-elections*
 
@@ -143,6 +144,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: service.civicpdx.org
                Path: /neighborhood-development*
 
@@ -155,6 +157,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: service.civicpdx.org
                Path: /housing-affordability*
 
@@ -167,6 +170,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: service.civicpdx.org
                Path: /disaster-resilience*
 
@@ -179,6 +183,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: service.civicpdx.org
                Path: /transportation-systems*
 

--- a/services/disaster-resilience-service/service.yaml
+++ b/services/disaster-resilience-service/service.yaml
@@ -22,6 +22,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -106,6 +110,22 @@ Resources:
                   Values:
                     - !Ref Path
  
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 36
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/housing-affordability-service/service.yaml
+++ b/services/housing-affordability-service/service.yaml
@@ -22,6 +22,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -106,6 +110,22 @@ Resources:
                   Values:
                     - !Ref Path
  
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 21
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/local-elections-service/service.yaml
+++ b/services/local-elections-service/service.yaml
@@ -22,6 +22,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -106,6 +110,22 @@ Resources:
                   Values:
                     - !Ref Path
  
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 31
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/neighborhood-development-service/service.yaml
+++ b/services/neighborhood-development-service/service.yaml
@@ -22,6 +22,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -105,7 +109,22 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
- 
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 26
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/transportation-systems-service/service.yaml
+++ b/services/transportation-systems-service/service.yaml
@@ -22,6 +22,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -104,8 +108,23 @@ Resources:
                     - !Ref Host
                 - Field: path-pattern
                   Values:
+                    - !Ref Path 
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 41
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
                     - !Ref Path
- 
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward


### PR DESCRIPTION
This PR enables the five 2018 API containers to answer requests sent via https:
- https://service.civicpdx.org/disaster-resilience/
- https://service.civicpdx.org/housing-affordability/
- https://service.civicpdx.org/local-elections/
- https://service.civicpdx.org/neighborhood-development/
- https://service.civicpdx.org/transportation-systems/

Unfortunately, the API applications themselves aren't https-aware, so they are still returning responses with embedded http:// URLs, such as https://service.civicpdx.org/housing-affordability/api/harvardjchs/ returning 

```
HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 49759,
    "next": "http://service.civicpdx.org/housing-affordability/api/harvardjchs/?limit=10&offset=10",
...
```

or https://service.civicpdx.org/transportation-systems/PUDL/ returning

```
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "sensor/locations": "http://service.civicpdx.org/transportation-systems/PUDL/sensor/locations/"
}
```