### PR TITLE
Add 443 listeners to frontends

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -61,7 +61,7 @@ Resources:
                 VPC: !GetAtt VPC.Outputs.VPC
                 Subnets: !GetAtt VPC.Outputs.PublicSubnets
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.LoadBalancerSecurityGroup
-                PublicAlbAcmCertificate: arn:aws:acm:us-west-2:845828040396:certificate/22d1eab8-34cb-48ed-b404-91a3ecaeed08
+                PublicAlbAcmCertificate: arn:aws:acm:us-west-2:845828040396:certificate/ca1d5fc4-f21a-4305-a656-8ac91cd527bc
 
     ECS:
         Type: AWS::CloudFormation::Stack

--- a/master.yaml
+++ b/master.yaml
@@ -106,6 +106,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 Host: 2017.civicpdx.org
                 Host2: civicpdx.org
                 Path: /*
@@ -119,6 +120,7 @@ Resources:
                Cluster: !GetAtt ECS.Outputs.Cluster
                DesiredCount: 2
                Listener: !GetAtt ALB.Outputs.Listener
+               ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                Host: civicplatform.org
                Path: /*
 

--- a/services/civic-2017-service/service.yaml
+++ b/services/civic-2017-service/service.yaml
@@ -19,6 +19,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -113,11 +117,27 @@ Resources:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward
 
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 11
+            Conditions:
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
     ListenerRule2:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 11
+            Priority: 12
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/civic-2018-service/service.yaml
+++ b/services/civic-2018-service/service.yaml
@@ -15,14 +15,18 @@ Parameters:
         Type: Number
         Default: 2
 
-    Listener:
-        Description: The Application Load Balancer listener to register with
-        Type: String
-
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
         Default: civicplatform.org
+
+    Listener:
+        Description: The Application Load Balancer listener to register with
+        Type: String
+
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
 
     Path:
         Description: The path to register with the Application Load Balancer
@@ -96,6 +100,22 @@ Resources:
         Properties:
             ListenerArn: !Ref Listener
             Priority: 45
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 46
             Conditions:
                 - Field: host-header
                   Values:


### PR DESCRIPTION
Now the frontend containers can be reached with https-enabled URLs:
- https://civicplatform.org/
- https://2017.civicpdx.org/