### PR TITLE
Add 443 listeners to 2017 APIs

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -218,6 +218,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-budget-config
                 DeployTarget: integration
                 ProjSettingsDir: budget_proj
@@ -233,6 +234,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-emerresponse-config
                 DeployTarget: integration
                 ProjSettingsDir: emerresponseAPI
@@ -248,6 +250,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-homeless-config
                 DeployTarget: integration
                 ProjSettingsDir: homelessAPI
@@ -263,6 +266,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-housing-config
                 DeployTarget: integration
                 ProjSettingsDir: housingAPI
@@ -278,6 +282,7 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 0
                 Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-transportation-config
                 DeployTarget: integration
                 ProjSettingsDir: transDjango

--- a/services/budget-service/service.yaml
+++ b/services/budget-service/service.yaml
@@ -21,6 +21,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     ConfigBucket:
         Description: The configuration bucket we want to use
         Type: String
@@ -114,7 +118,23 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 8
+            Priority: 1
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 2
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/civic-2017-service/service.yaml
+++ b/services/civic-2017-service/service.yaml
@@ -104,7 +104,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 10
+            Priority: 15
             Conditions:
                 - Field: path-pattern
                   Values:
@@ -121,7 +121,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 11
+            Priority: 16
             Conditions:
                 - Field: path-pattern
                   Values:
@@ -137,7 +137,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 12
+            Priority: 17
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/emergency-service/service.yaml
+++ b/services/emergency-service/service.yaml
@@ -21,6 +21,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     ConfigBucket:
         Description: The configuration bucket we want to use
         Type: String
@@ -114,6 +118,22 @@ Resources:
         Properties:
             ListenerArn: !Ref Listener
             Priority: 3
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 4
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/homeless-service/service.yaml
+++ b/services/homeless-service/service.yaml
@@ -21,6 +21,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     ConfigBucket:
         Description: The configuration bucket we want to use
         Type: String
@@ -114,6 +118,22 @@ Resources:
         Properties:
             ListenerArn: !Ref Listener
             Priority: 5
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 6
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/housing-service/service.yaml
+++ b/services/housing-service/service.yaml
@@ -21,6 +21,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     ConfigBucket:
         Description: The configuration bucket we want to use
         Type: String
@@ -113,7 +117,23 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 6
+            Priority: 7
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 8
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -21,6 +21,10 @@ Parameters:
         Description: The Application Load Balancer listener to register with
         Type: String
 
+    ListenerTls:
+        Description: The 443 Application Load Balancer listener to register with
+        Type: String
+
     ConfigBucket:
         Description: The configuration bucket we want to use
         Type: String
@@ -113,7 +117,23 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 7
+            Priority: 9
+            Conditions:
+                - Field: host-header
+                  Values:
+                    - !Ref Host
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    ListenerRuleTls:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref ListenerTls
+            Priority: 10
             Conditions:
                 - Field: host-header
                   Values:


### PR DESCRIPTION
This PR enables the five 2017 API containers to answer requests sent via https:

https://service.civicpdx.org/budget/
https://service.civicpdx.org/emergency/
https://service.civicpdx.org/homeless/
https://service.civicpdx.org/housing/
https://service.civicpdx.org/transport/

Unfortunately, the API applications themselves aren't https-aware, so they're probably still returning responses with embedded http:// URLs.