### PR TITLE
Deprioritize the 2017 APIs

### DIFF
--- a/services/budget-service/service.yaml
+++ b/services/budget-service/service.yaml
@@ -118,7 +118,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 1
+            Priority: 50
             Conditions:
                 - Field: host-header
                   Values:
@@ -134,7 +134,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 2
+            Priority: 51
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/emergency-service/service.yaml
+++ b/services/emergency-service/service.yaml
@@ -117,7 +117,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 3
+            Priority: 52
             Conditions:
                 - Field: host-header
                   Values:
@@ -133,7 +133,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 4
+            Priority: 53
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/homeless-service/service.yaml
+++ b/services/homeless-service/service.yaml
@@ -117,7 +117,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 5
+            Priority: 54
             Conditions:
                 - Field: host-header
                   Values:
@@ -133,7 +133,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 6
+            Priority: 55
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/housing-service/service.yaml
+++ b/services/housing-service/service.yaml
@@ -117,7 +117,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 7
+            Priority: 56
             Conditions:
                 - Field: host-header
                   Values:
@@ -133,7 +133,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 8
+            Priority: 57
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -117,7 +117,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 9
+            Priority: 58
             Conditions:
                 - Field: host-header
                   Values:
@@ -133,7 +133,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 10
+            Priority: 59
             Conditions:
                 - Field: host-header
                   Values:


### PR DESCRIPTION
Increase the Priority values of the 2017 APIs so that /housing* no longer overrides /housing-affordability*

See [issue 122](https://github.com/hackoregon/civic-devops/issues/212) for details.