### PR TITLE
Bring Transport API back to life

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -280,7 +280,7 @@ Resources:
             Parameters:
                 VPC: !GetAtt VPC.Outputs.VPC
                 Cluster: !GetAtt ECS.Outputs.Cluster
-                DesiredCount: 0
+                DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ConfigBucket: hacko-transportation-config

--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -76,7 +76,7 @@ Resources:
                 - Name: transport-service
                   Essential: true
                   Image: 845828040396.dkr.ecr.us-west-2.amazonaws.com/integration/transport-service:latest
-                  Memory: 2048
+                  Memory: 500
                   Environment:
                     - Name: CONFIG_BUCKET
                       Value: !Ref ConfigBucket


### PR DESCRIPTION
It's time to see if the old beast can cough up some API responses, even if at least one of its endpoints is still too sick to respond.