### PR TITLE
Sagemaker Data Science Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 container-repos.md
+*.out.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+S3BUCKET = "hacko-infrastructure-cfn"
+
+datascience:
+	@echo "Packaging and deploying the SageMaker Data Science Environment";
+	cd sagemaker && aws cloudformation package \
+		--s3-bucket $(S3BUCKET) \
+		--s3-prefix sagemaker \
+		--template sagemaker.yaml \
+		--output-template-file sagemaker.out.yaml;
+	cd sagemaker && aws cloudformation deploy \
+	  --template-file sagemaker.out.yaml \
+		--stack-name DataScienceLab \
+		--capabilities CAPABILITY_NAMED_IAM;

--- a/sagemaker/functions/auto-shutdown.py
+++ b/sagemaker/functions/auto-shutdown.py
@@ -1,0 +1,31 @@
+import boto3
+
+def lambda_handler(event, context):
+    stopCount = 0
+    keepaliveCount = 0
+    totalCount = 0
+
+    client = boto3.client('sagemaker')
+    notebooks = client.list_notebook_instances(MaxResults=100)['NotebookInstances']
+    totalCount = len(notebooks)
+    print('Found %s Notebook Instances' % totalCount)
+
+    for notebook in notebooks:
+        tags = client.list_tags(ResourceArn=notebook['NotebookInstanceArn'])['Tags']
+        if notebook['NotebookInstanceStatus'] != 'Stopped':
+            keepalive = has_keepalive(tags)
+            if keepalive:
+                keepaliveCount += 1
+                print('Keeping notebook %s alive' % notebook['NotebookInstanceName'])
+            else:
+                print('Stopping a notebook %s' % notebook['NotebookInstanceName'])
+                stopCount += 1
+                client.stop_notebook_instance(NotebookInstanceName=notebook['NotebookInstanceName'])
+
+    return { 'stopped': stopCount, 'kept': keepaliveCount, 'total': totalCount }
+
+def has_keepalive(tags):
+    for tag in tags:
+        if tag['Key'] == 'keepalive' and tag['Value'] == 'true':
+            return True
+    return False

--- a/sagemaker/sagemaker.yaml
+++ b/sagemaker/sagemaker.yaml
@@ -1,0 +1,115 @@
+Transform: AWS::Serverless-2016-10-31
+
+Description: >
+  Creates the Data Science lab within AWS Sagemaker. Responsible for provisioning
+  Notebook instances, associating roles and S3 buckets, and deploying lambda
+  functions for automating stopping instances based on idle time.
+
+Resources:
+  SageMakerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: DataScienceNotebook
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "sagemaker.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: notebook-data-science
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - arn:aws:s3:::hacko-data-archive/*
+                  - arn:aws:s3:::hacko-data-science/*
+                  - arn:aws:s3:::hacko-data-staging/*
+              - Effect: Allow
+                Action:
+                  - cloudwatch:DeleteAlarms
+                  - cloudwatch:DescribeAlarms
+                  - cloudwatch:GetMetricData
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:ListMetrics
+                  - cloudwatch:PutMetricAlarm
+                  - cloudwatch:PutMetricData
+                Resource:
+                  - "*"
+
+  AutoShutdownFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: auto-shutdown.lambda_handler
+      Runtime: python3.7
+      CodeUri: ./functions/
+      Description: "Stops any Notebook Instances that aren't tagged keepalive"
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Action:
+                - "sagemaker:ListNotebookInstances"
+                - "sagemaker:ListTags"
+                - "sagemaker:StopNotebookInstance"
+              Resource: "*"
+
+  ScheduledRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "ScheduledRule"
+      ScheduleExpression: "cron(0 9 * * ? *)"
+      State: "ENABLED"
+      Targets:
+        -
+          Arn: !GetAtt AutoShutdownFunction.Arn
+          Id: "AutoShutdownFunction"
+
+  PermissionForEventsToInvokeLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName:
+        Ref: "AutoShutdownFunction"
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt ScheduledRule.Arn
+
+
+### NOTEBOOK INSTANCES ############################################################
+
+
+  # Standard Instance
+  ###################
+
+  # CFNInstance:
+  #   Type: AWS::SageMaker::NotebookInstance
+  #   Properties:
+  #     InstanceType: ml.t2.medium
+  #     NotebookInstanceName: CFNInstance
+  #     RoleArn: !GetAtt SageMakerRole.Arn
+  #     VolumeSizeInGB: 5
+
+  # Persistent Instance
+  #####################
+
+  # CFNInstanceKeep:
+  #   Type: AWS::SageMaker::NotebookInstance
+  #   Properties:
+  #     InstanceType: ml.t2.medium
+  #     NotebookInstanceName: CFNInstanceKeep
+  #     RoleArn: !GetAtt SageMakerRole.Arn
+  #     VolumeSizeInGB: 5
+  #     Tags:
+  #       -
+  #         Key: keepalive
+  #         Value: true


### PR DESCRIPTION
Adds the following:

1. The necessary role for creating Notebook instances in Sagemaker
2. A Lambda function for automatically shutting down Notebook instances
3. A cron-rule to run said Lambda nightly at 2am PT
4. Examples for creating a standard notebook instance or a "keepalive" instance (one that doesn't get shutdown nightly)
5. A Makefile to package and deploy the stack nightly