### PR TITLE
Allow unique TargetGroup names

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -12,14 +12,14 @@ Parameters:
 
     VPC:
         Type: AWS::EC2::VPC::Id
-        Description: Choose which VPC the Applicaion Load Balancer should be deployed to
+        Description: Choose which VPC the Application Load Balancer should be deployed to
 
     Subnets:
-        Description: Choose which subnets the Applicaion Load Balancer should be deployed to
+        Description: Choose which subnets the Application Load Balancer should be deployed to
         Type: List<AWS::EC2::Subnet::Id>
 
     SecurityGroup:
-        Description: Select the Security Group to apply to the Applicaion Load Balancer
+        Description: Select the Security Group to apply to the Application Load Balancer
         Type: AWS::EC2::SecurityGroup::Id
 
     PublicAlbAcmCertificate:

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -76,7 +76,7 @@ Resources:
     DefaultTargetGroup:
         Type: AWS::ElasticLoadBalancingV2::TargetGroup
         Properties:
-            Name: default
+            Name: !Sub ${EnvironmentName}-default
             VpcId: !Ref VPC
             Port: 80
             Protocol: HTTP

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -1,7 +1,7 @@
 Description: >
     This template deploys an Application Load Balancer that exposes our various ECS services.
     We create them it a seperate nested template, so it can be referenced by all of the other nested templates.
-    Last Modified: 15 July 2018
+    Last Modified: 27 May 2019
     By Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:


### PR DESCRIPTION
This stack currently can only deploy one copy per account because of collision on DefaultTargetGroup.

When I attempt to deploy a new stack with the current templates, CloudFormation fails to complete and reports the following errors:

<img width="1162" alt="Screen Shot 2019-05-27 at 14 04 48" src="https://user-images.githubusercontent.com/6953053/58439381-89f5b680-8088-11e9-8128-bb5476a79fee.png">

This implements https://github.com/aws-samples/ecs-refarch-cloudformation/pull/15 to overcome that limitation.