### PR TITLE
Add SSM policy to enable all cluster roles to access SSM

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -137,7 +137,8 @@ Resources:
         Type: AWS::IAM::Role
         Properties:
             Path: /
-            RoleName: !Sub ${EnvironmentName}-ECSRole-${AWS::Region}
+            RoleName: !Sub hack-integration-ECSRole-${AWS::Region}
+#            RoleName: !Sub ${EnvironmentName}-ECSRole-${AWS::Region}
             AssumeRolePolicyDocument: |
                 {
                     "Statement": [{
@@ -172,6 +173,41 @@ Resources:
                             ],
                             "Resource": "*"
                         }]
+                    }
+                - PolicyName: ssm-access
+                  PolicyDocument: 
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ssm:DescribeParameters"
+                                ],
+                                "Resource": "*"
+                            },
+                            {
+                                "Sid": "Stmt1482841904000",
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ssm:GetParameters"
+                                ],
+                                "Resource": [
+                                    "arn:aws:ssm:us-west-2:845828040396:parameter/staging/2018/*",
+                                    "arn:aws:ssm:us-west-2:845828040396:parameter/production/2018/*"
+                                ]
+                            },
+                            {
+                                "Sid": "Stmt1482841948000",
+                                "Effect": "Allow",
+                                "Action": [
+                                    "kms:Decrypt"
+                                ],
+                                "Resource": [
+                                    "arn:aws:kms:us-west-2:845828040396:key/0280a59b-d8f5-44e0-8b51-80aec2f27275"
+                                ]
+                            }
+                        ]
                     }
 
     ECSInstanceProfile:

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -193,7 +193,9 @@ Resources:
                                 ],
                                 "Resource": [
                                     "arn:aws:ssm:us-west-2:845828040396:parameter/staging/2018/*",
-                                    "arn:aws:ssm:us-west-2:845828040396:parameter/production/2018/*"
+                                    "arn:aws:ssm:us-west-2:845828040396:parameter/production/2018/*",
+                                    "arn:aws:ssm:us-west-2:845828040396:parameter/staging/2019/*",
+                                    "arn:aws:ssm:us-west-2:845828040396:parameter/production/2019/*"
                                 ]
                             },
                             {

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -137,8 +137,7 @@ Resources:
         Type: AWS::IAM::Role
         Properties:
             Path: /
-            RoleName: !Sub hack-integration-ECSRole-${AWS::Region}
-#            RoleName: !Sub ${EnvironmentName}-ECSRole-${AWS::Region}
+            RoleName: !Sub ${EnvironmentName}-ECSRole-${AWS::Region}
             AssumeRolePolicyDocument: |
                 {
                     "Statement": [{


### PR DESCRIPTION
Resolves https://github.com/hackoregon/civic-devops/issues/241

SSM parameters were only accessible to the one ECS cluster running a manually-enhanced Role that includes `ssm:GetParameters` and `kms:Decrypt` actions for the existing resources.

I've hard-coded those values for now in the `ecs-cluster.yaml` template to ensure we have a working cluster.  Separate ticket will be filed to refactor this into parameters that are injected through the `master.yaml` so that this stack configuration could be re-used for different environments.