### PR TITLE
Updating Listener priorities to make room for 2019 APIs

### DIFF
--- a/services/disaster-resilience-service/service.yaml
+++ b/services/disaster-resilience-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     ECS Service - HackOregon 2018 disaster-resilience API
-    Last Modified: 15 July 2018
+    Last Modified: 30 June 2019
     By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -98,7 +98,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 35
+            Priority: 30
             Conditions:
                 - Field: host-header
                   Values:
@@ -115,7 +115,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 36
+            Priority: 31
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/housing-affordability-service/service.yaml
+++ b/services/housing-affordability-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     ECS Service - HackOregon 2018 housing-affordability API
-    Last Modified: 15 July 2018
+    Last Modified: 30 June 2019
     By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -98,7 +98,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 20
+            Priority: 32
             Conditions:
                 - Field: host-header
                   Values:
@@ -115,7 +115,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 21
+            Priority: 33
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/local-elections-service/service.yaml
+++ b/services/local-elections-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     ECS Service - HackOregon 2018 local-elections API
-    Last Modified: 15 July 2018
+    Last Modified: 30 June 2019
     By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -98,7 +98,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 30
+            Priority: 34
             Conditions:
                 - Field: host-header
                   Values:
@@ -115,7 +115,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 31
+            Priority: 35
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/neighborhood-development-service/service.yaml
+++ b/services/neighborhood-development-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     ECS Service - HackOregon 2018 neighborhood-development API
-    Last Modified: 15 July 2018
+    Last Modified: 30 June 2019
     By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -98,7 +98,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 25
+            Priority: 36
             Conditions:
                 - Field: host-header
                   Values:
@@ -114,7 +114,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 26
+            Priority: 37
             Conditions:
                 - Field: host-header
                   Values:

--- a/services/transportation-systems-service/service.yaml
+++ b/services/transportation-systems-service/service.yaml
@@ -1,6 +1,6 @@
 Description: >
     ECS Service - HackOregon 2018 transportation-systems API
-    Last Modified: 15 July 2018
+    Last Modified: 30 June 2019
     By Ian Turner (iant18150@gmail.com), Mike Lonergan (mikethecanuck@gmail.com)
 
 Parameters:
@@ -98,7 +98,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref Listener
-            Priority: 40
+            Priority: 38
             Conditions:
                 - Field: host-header
                   Values:
@@ -114,7 +114,7 @@ Resources:
         Type: AWS::ElasticLoadBalancingV2::ListenerRule
         Properties:
             ListenerArn: !Ref ListenerTls
-            Priority: 41
+            Priority: 39
             Conditions:
                 - Field: host-header
                   Values:


### PR DESCRIPTION
Addresses https://github.com/hackoregon/civic-devops/issues/247, and in conjunction with https://github.com/hackoregon/civic-devops/pull/248 closes 247.

Reallocates the listener priorities such that 2018 API services are in a contiguous block 30-39, and makes room for 2019 API services to occupy the 20-29 block.