### PR TITLE
Tune the Cpu & Memory allocations for all Fargate containers

### DIFF
--- a/fargate-services/2019-fargate-api.yaml
+++ b/fargate-services/2019-fargate-api.yaml
@@ -138,9 +138,9 @@ Resources:
                   Image: !Ref EcrImage
                   ## NOTE: this looks duplicative of the Cpu/Memory defined just a few lines above at the Task Definition level
                   # CPU and Memory reservations are set to 50% of the default values specified above
-                  Cpu: TaskCpu
-                  Memory: TaskMemory
-                  MemoryReservation: TaskMemory
+                  Cpu: !Ref TaskCpu
+                  Memory: !Ref TaskMemory
+                  MemoryReservation: !Ref TaskMemory
                   PortMappings:
                     - ContainerPort: !Ref ContainerPort
                   LogConfiguration:

--- a/fargate-services/2019-fargate-api.yaml
+++ b/fargate-services/2019-fargate-api.yaml
@@ -136,11 +136,11 @@ Resources:
                 - Name: !Ref ProjectName
                   Essential: true
                   Image: !Ref EcrImage
-                  ## NOTE: this looks duplicative of the Cpu/Memory defined just a few lines above at the Task Definition level
-                  # CPU and Memory reservations are set to 50% of the default values specified above
+                  ## NOTE: these Container resource values can be smaller than Task if there are multiple Containers per Task
+                  ## Since we deploy one Container per Task, there's no reason to use different values
                   Cpu: !Ref TaskCpu
-                  Memory: !Ref TaskMemory
-                  MemoryReservation: !Ref TaskMemory
+                  Memory: !Ref TaskMemory # This is the minimum memory
+                  MemoryReservation: !Ref TaskMemory # This is the upper burstable limit
                   PortMappings:
                     - ContainerPort: !Ref ContainerPort
                   LogConfiguration:

--- a/fargate-services/2019-fargate-api.yaml
+++ b/fargate-services/2019-fargate-api.yaml
@@ -138,9 +138,9 @@ Resources:
                   Image: !Ref EcrImage
                   ## NOTE: this looks duplicative of the Cpu/Memory defined just a few lines above at the Task Definition level
                   # CPU and Memory reservations are set to 50% of the default values specified above
-                  Cpu: 256
-                  Memory: 512
-                  MemoryReservation: 512
+                  Cpu: TaskCpu
+                  Memory: TaskMemory
+                  MemoryReservation: TaskMemory
                   PortMappings:
                     - ContainerPort: !Ref ContainerPort
                   LogConfiguration:

--- a/master.yaml
+++ b/master.yaml
@@ -14,8 +14,8 @@ Description: >
     Based on AWSLabs ECS Reference Architecture
     https://github.com/awslabs/ecs-refarch-cloudformation
 
-    Last Modified: 14 July 2019
-    Author Dan Carr (ddcarr@gmail.com), Mike Lonergan (mikethecanuck@gmail.com), Ian Turner (iant18150@gmail.com)
+    Last Modified: 31 July 2019
+    Author Mike Lonergan (mikethecanuck@gmail.com), Ian Turner (iant18150@gmail.com), Dan Carr (ddcarr@gmail.com)
 
 Parameters:
 
@@ -160,8 +160,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 1
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -185,8 +185,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 0
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -210,8 +210,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 0
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -235,8 +235,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 0
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -260,8 +260,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 1
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -285,8 +285,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 0
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -383,8 +383,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 1
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
@@ -411,8 +411,8 @@ Resources:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 DesiredCount: 1
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 512
-                TaskMemory: 1024
+                TaskCpu: 256
+                TaskMemory: 512
                 ContainerPort: 8000
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets

--- a/master.yaml
+++ b/master.yaml
@@ -149,7 +149,7 @@ Resources:
             Parameters:
                 ProjectName: 2019-examplar
                 DeploymentSsmNamespace: /staging
-                HealthCheckPathName: /examplar/schema/
+                HealthCheckPathName: /examplar/health/
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ListenerRulePriority: 77


### PR DESCRIPTION
With Fargate's minimum container allocation of 256 (.25 CPU) and 512 (0.5 GB memory), might as well tune down everything that's nowhere near those allocation levels.