### PR TITLE
Enable Transportation 2019 container deployment

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -274,16 +274,16 @@ Resources:
             Parameters:
                 ProjectName: 2019-transportation
                 DeploymentSsmNamespace: /staging
-                HealthCheckPathName: /transportation2019/schema/
+                HealthCheckPathName: /transportation2019/v1/schema/
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 ListenerRulePriority: 28
                 ListenerRuleTlsPriority: 29
                 Host: service.civicpdx.org
-                Path: /transportation2019*
+                Path: /transportation2019/*
                 VPC: !GetAtt VPC.Outputs.VPC
                 Cluster: !GetAtt ECS.Outputs.Cluster
-                DesiredCount: 0
+                DesiredCount: 1
                 ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
                 TaskCpu: 256
                 TaskMemory: 512


### PR DESCRIPTION
Update health check route to Transportation's versioned route

Trying out a more specific Path as well, to confirm I understand how this works.