### PR TITLE
Deploy new DNS via CloudFormation

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -102,9 +102,14 @@ Outputs:
     PublicAlbDnsName:
         Value:
             !GetAtt LoadBalancer.DNSName
+
     PublicAlbHostname:
         Value:
             !If [ NoSslCertificate, !Join [ '', [ 'http://', !GetAtt LoadBalancer.DNSName ] ], !Join [ '', [ 'https://', !GetAtt LoadBalancer.DNSName ] ] ]
+
     SslCertificate:
         Value:
             !If [ SslCertificate, True, False ]
+    
+    CanonicalHostedZoneId:
+        Value: !GetAtt LoadBalancer.CanonicalHostedZoneID

--- a/master.yaml
+++ b/master.yaml
@@ -76,6 +76,21 @@ Resources:
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSHostSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
 
+#### DNS records ####
+
+    DNSFrontend2017:
+        Type: AWS::Route53::RecordSetGroup
+        Properties:
+            HostedZoneName: civicplatform.org.
+            Comment: Zone apex alias targeted to ALB LoadBalancer
+            RecordSets:
+            - Name: 2017.civicplatform.org.
+              Type: A
+              AliasTarget:
+                HostedZoneId: !GetAtt ALB.CanonicalHostedZoneNameID
+                DNSName: !GetAtt ALB.DNSName
+
+
 ##### EC2 instances #####
 
     BastionHost:

--- a/master.yaml
+++ b/master.yaml
@@ -90,6 +90,28 @@ Resources:
                 HostedZoneId: !GetAtt ALB.Outputs.CanonicalHostedZoneId
                 DNSName: !GetAtt ALB.Outputs.PublicAlbDnsName
 
+    DNSFrontend2017Alias:
+        Type: AWS::Route53::RecordSet
+        Properties:
+            HostedZoneName: civicpdx.org.
+            Comment: Redirecting a legacy domain
+            Name: 2017.civicpdx.org
+            Type: CNAME
+            TTL: '900'
+            ResourceRecords: 
+            - 2017.civicplatform.org
+
+    DNSFrontend2018Alias:
+        Type: AWS::Route53::RecordSet
+        Properties:
+            HostedZoneName: civicplatform.org.
+            Comment: Redirecting the www
+            Name: www.civicplatform.org
+            Type: CNAME
+            TTL: '900'
+            ResourceRecords: 
+            - civicplatform.org
+
 ##### EC2 instances #####
 
     BastionHost:
@@ -137,8 +159,8 @@ Resources:
                 DesiredCount: 2
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
-                Host: 2017.civicpdx.org
-                Host2: civicpdx.org
+                Host: 2017.civicplatform.org
+                Host2: www.civicpdx.org
                 Path: /*
 
     Civic2018Service:
@@ -152,6 +174,7 @@ Resources:
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
                 Host: civicplatform.org
+                # Host2: www.civicplatform.org
                 Path: /*
 
 # 2019 API services - Fargate

--- a/master.yaml
+++ b/master.yaml
@@ -87,9 +87,8 @@ Resources:
             - Name: 2017.civicplatform.org.
               Type: A
               AliasTarget:
-                HostedZoneId: !GetAtt ALB.CanonicalHostedZoneNameID
-                DNSName: !GetAtt ALB.DNSName
-
+                HostedZoneId: !GetAtt ALB.Outputs.CanonicalHostedZoneId
+                DNSName: !GetAtt ALB.Outputs.PublicAlbDnsName
 
 ##### EC2 instances #####
 


### PR DESCRIPTION
Partially addresses https://github.com/hackoregon/civic-devops/issues/267.

Intended to give us the ability to host 2017.civicplatform.org via ALB-load-balanced front-end ECS service.

Ultimate goal is to migrate 2017 frontend service to this new DNS identity 2017.civicplatform.org from civicpdx.org and 2017.civicpdx.org.

Then we can migrate those old identities to CNAME records, pointing civicpdx.org and 2017.civicpdx.org to 2017.civicplatform.org

This will give us the ability to refactor the two `civic-2017-service` and `civic-2018-service` into a single Fargate-based template to deploy the two frontend containers.