### PR TITLE
Remove 2019 Disaster service and reshuffle ALB priorities

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -142,56 +142,6 @@ Resources:
 
 # 2019 API services - Fargate
 
-    2019Exemplar:
-        Type: AWS::CloudFormation::Stack
-        Properties:
-            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/fargate-services/2019-fargate-api.yaml
-            Parameters:
-                ProjectName: 2019-examplar
-                DeploymentSsmNamespace: /staging
-                HealthCheckPathName: /examplar/health/
-                Listener: !GetAtt ALB.Outputs.Listener
-                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
-                ListenerRulePriority: 77
-                ListenerRuleTlsPriority: 78
-                Host: service.civicpdx.org
-                Path: /examplar*
-                VPC: !GetAtt VPC.Outputs.VPC
-                Cluster: !GetAtt ECS.Outputs.Cluster
-                DesiredCount: 1
-                ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 256
-                TaskMemory: 512
-                ContainerPort: 8000
-                SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
-                Subnets: !GetAtt VPC.Outputs.PrivateSubnets
-                EcrImage: 845828040396.dkr.ecr.us-west-2.amazonaws.com/testing/2019-examplar:latest
-
-    2019Disaster:
-        Type: AWS::CloudFormation::Stack
-        Properties:
-            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/fargate-services/2019-fargate-api.yaml
-            Parameters:
-                ProjectName: 2019-disaster
-                DeploymentSsmNamespace: /staging
-                HealthCheckPathName: /disaster/schema/
-                Listener: !GetAtt ALB.Outputs.Listener
-                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
-                ListenerRulePriority: 20
-                ListenerRuleTlsPriority: 21
-                Host: service.civicpdx.org
-                Path: /disaster2019*
-                VPC: !GetAtt VPC.Outputs.VPC
-                Cluster: !GetAtt ECS.Outputs.Cluster
-                DesiredCount: 0
-                ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 256
-                TaskMemory: 512
-                ContainerPort: 8000
-                SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
-                Subnets: !GetAtt VPC.Outputs.PrivateSubnets
-                EcrImage: 845828040396.dkr.ecr.us-west-2.amazonaws.com/staging/2019-disaster:latest
-
     2019Education:
         Type: AWS::CloudFormation::Stack
         Properties:
@@ -202,8 +152,8 @@ Resources:
                 HealthCheckPathName: /education/schema/
                 Listener: !GetAtt ALB.Outputs.Listener
                 ListenerTls: !GetAtt ALB.Outputs.ListenerTls
-                ListenerRulePriority: 22
-                ListenerRuleTlsPriority: 23
+                ListenerRulePriority: 20
+                ListenerRuleTlsPriority: 21
                 Host: service.civicpdx.org
                 Path: /education2019*
                 VPC: !GetAtt VPC.Outputs.VPC
@@ -216,6 +166,32 @@ Resources:
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
                 EcrImage: 845828040396.dkr.ecr.us-west-2.amazonaws.com/staging/2019-education:latest
+
+## This one supports the "examplar" (sic) which is the template for all 2019 API projects
+    2019Exemplar:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/fargate-services/2019-fargate-api.yaml
+            Parameters:
+                ProjectName: 2019-examplar
+                DeploymentSsmNamespace: /staging
+                HealthCheckPathName: /examplar/health/
+                Listener: !GetAtt ALB.Outputs.Listener
+                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
+                ListenerRulePriority: 22
+                ListenerRuleTlsPriority: 23
+                Host: service.civicpdx.org
+                Path: /examplar*
+                VPC: !GetAtt VPC.Outputs.VPC
+                Cluster: !GetAtt ECS.Outputs.Cluster
+                DesiredCount: 1
+                ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
+                TaskCpu: 256
+                TaskMemory: 512
+                ContainerPort: 8000
+                SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
+                Subnets: !GetAtt VPC.Outputs.PrivateSubnets
+                EcrImage: 845828040396.dkr.ecr.us-west-2.amazonaws.com/testing/2019-examplar:latest
 
     2019Housing:
         Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Officially, the 2019 Disaster team is enhancing their 2018 Disaster Resilience API so they won't need a 2019 container service.

Also acknowledge that we're officially supporting the Exemplar (or examplar if you're Brian) container for the forseeable.

Reshuffled the listener priorities for the new set.