### PR TITLE
Remove the never-did-exist 2019 Education API service

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -203,31 +203,6 @@ Resources:
 
 # 2019 API services - Fargate
 
-    2019Education:
-        Type: AWS::CloudFormation::Stack
-        Properties:
-            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/fargate-services/2019-fargate-api.yaml
-            Parameters:
-                ProjectName: 2019-education
-                DeploymentSsmNamespace: /staging
-                HealthCheckPathName: /education/schema/
-                Listener: !GetAtt ALB.Outputs.Listener
-                ListenerTls: !GetAtt ALB.Outputs.ListenerTls
-                ListenerRulePriority: 20
-                ListenerRuleTlsPriority: 21
-                Host: service.civicpdx.org
-                Path: /education2019*
-                VPC: !GetAtt VPC.Outputs.VPC
-                Cluster: !GetAtt ECS.Outputs.Cluster
-                DesiredCount: 0
-                ECSTaskExecutionRole: !GetAtt ECS.Outputs.ECSTaskExecutionRole
-                TaskCpu: 256
-                TaskMemory: 512
-                ContainerPort: 8000
-                SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSTaskSecurityGroup
-                Subnets: !GetAtt VPC.Outputs.PrivateSubnets
-                EcrImage: 845828040396.dkr.ecr.us-west-2.amazonaws.com/staging/2019-education:latest
-
 ## This one supports the "examplar" (sic) which is the template for all 2019 API projects
     2019Exemplar:
         Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
API was never created, so now that we've crossed Demo Day it seems safe to remove this unnecessary resource.