### PR TITLE
[WIP] Add an auto-redirect for all HTTP to HTTPs

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -69,6 +69,26 @@ Resources:
                 - Type: forward
                   TargetGroupArn: !Ref DefaultTargetGroup
 
+    # ALB global redirect from HTTP to HTTPS
+
+    PublicLoadBalancerHttpRedirectListener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        DependsOn:
+        - LoadBalancer
+        Properties:
+        DefaultActions:
+            - RedirectConfig:
+                Host: "#{host}"
+                Path: "/#{path}"
+                Port: 443
+                Protocol: "HTTPS"
+                Query: "#{query}"
+                StatusCode: HTTP_301
+            Type: redirect
+        LoadBalancerArn: !Ref LoadBalancer # don't know how to construct this - see https://stackoverflow.com/questions/52085478/aws-cloudformation-application-load-balancer-how-to-redirect-http-listener-to/53498717#53498717
+        Port: 80
+        Protocol: HTTP
+
     # We define a default target group here, as this is a mandatory Parameter
     # when creating an Application Load Balancer Listener. 
     # However, this is not used - instead a target group is created per-service 


### PR DESCRIPTION
Addresses https://github.com/hackoregon/civic-devops/issues/215

Adds a TLS-redirect at the ALB layer, so that none of our services need to be aware of HTTP/HTTPS distinctions.  At present, would affect all HTTP resources under the civicpdx.org, service.civicpdx.org and civicplatform.org domains.