### PR TITLE
[WIP] RDS support in CloudFormation

### DIFF
--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -38,6 +38,7 @@ Parameters:
     MasterPassword:
         Description: The database admin account password
         Type: String
+        # Type: SecureString # Works around error "SSM Secure reference is not supported in [AWS::CloudFormation::Stack/Properties/Parameters/MasterPassword]"
         ConstraintDescription: must contain only alphanumeric characters.
         Default: dummypassword2
 
@@ -63,7 +64,8 @@ Resources:
             DBSubnetGroupName: !Ref SubnetGroupName
             Engine: postgres
             MasterUsername: !Ref MasterUsername
-            MasterUserPassword: !Ref MasterPassword
+            # MasterUserPassword: !Ref MasterPassword
+            MasterUserPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
             MultiAZ: false
             Port: 5432
             PubliclyAccessible: true

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -1,39 +1,39 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
 
-AvailabilityZone:
-    Description: The AZ in which the RDS instance is deployed
-    Type: String
-    Default: us-west-2a
+    AvailabilityZone:
+        Description: The AZ in which the RDS instance is deployed
+        Type: String
+        Default: us-west-2a
 
-SecurityGroup:
-    Description: Select the Security Group to use for this RDS instance
-    Type: AWS::EC2::SecurityGroup::Id
+    SecurityGroup:
+        Description: Select the Security Group to use for this RDS instance
+        Type: AWS::EC2::SecurityGroup::Id
 
-SubnetGroup:
-    Description: Choose the subnet to which this RDS instance should be deployed
-    Type: AWS::RDS::DBSubnetGroup
+    SubnetGroup:
+        Description: Choose the subnet to which this RDS instance should be deployed
+        Type: AWS::RDS::DBSubnetGroup
 
-## Instance-specific parameters
+    ## Instance-specific parameters
 
-InstanceName:
-    Description: The name by which the DB instance is labelled in the RDS console
-    Type: String
+    InstanceName:
+        Description: The name by which the DB instance is labelled in the RDS console
+        Type: String
 
-InstanceSize:
-    Description: The instance class (size) for this RDS instance
-    Type: String
-    Default: db.t2.micro
+    InstanceSize:
+        Description: The instance class (size) for this RDS instance
+        Type: String
+        Default: db.t2.micro
 
-InstanceStorage:
-    Description: The amount of storage in GB allocated to the RDS instance
-    Type: String
+    InstanceStorage:
+        Description: The amount of storage in GB allocated to the RDS instance
+        Type: String
 
-## Database-specific parameters
+    ## Database-specific parameters
 
-DatabaseName:
-    Description: The name of the primary database on this instance
-    Type: String
+    DatabaseName:
+        Description: The name of the primary database on this instance
+        Type: String
 
 Resources:
 

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -29,15 +29,17 @@ Parameters:
         Type: String
         ConstraintDescription: must be between 5 and 1024 GB.
 
-    # MasterUsername:
-    #     Description: The database admin account username
-    #     Type: String
-    #     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+    MasterUsername:
+        Description: The database admin account username
+        Type: String
+        ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+        Default: dummyusername1
 
-    # MasterPassword:
-    #     Description: The database admin account password
-    #     Type: String
-    #     ConstraintDescription: must contain only alphanumeric characters.
+    MasterPassword:
+        Description: The database admin account password
+        Type: String
+        ConstraintDescription: must contain only alphanumeric characters.
+        Default: dummypassword2
 
     ## Database-specific parameters
 
@@ -60,8 +62,8 @@ Resources:
             DBName: !Ref DatabaseName
             DBSubnetGroupName: !Ref SubnetGroupName
             Engine: postgres
-            MasterUsername: dummyuser #todo
-            MasterUserPassword: dummypassword #todo
+            MasterUsername: !Ref MasterUsername
+            MasterUserPassword: !Ref MasterPassword
             MultiAZ: false
             Port: 5432
             PubliclyAccessible: true

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -1,3 +1,8 @@
+Description: >
+
+    This template creates an RDS instance 
+
+
 Parameters:
 
     AvailabilityZone:
@@ -42,6 +47,17 @@ Parameters:
         ConstraintDescription: must contain only alphanumeric characters.
         Default: dummypassword2
 
+    ## SSM path-specific parameters
+
+    SsmParameterPath:
+        Description: The path in the SSM Parameter Store in which the RDS creds are stored
+        Type: String
+
+    PasswordParamVersion: 
+        Description: The specific version of the SSM Parameter Store parameter to retrieve - all usage of {{resolve}} require this at time of writing this template
+        Type: String
+        Default: 1
+
     ## Database-specific parameters
 
     DatabaseName:
@@ -63,9 +79,12 @@ Resources:
             DBName: !Ref DatabaseName
             DBSubnetGroupName: !Ref SubnetGroupName
             Engine: postgres
-            MasterUsername: !Ref MasterUsername
-            # MasterUserPassword: !Ref MasterPassword
-            MasterUserPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
+            ### All usage of {{resolve}} require explictly specifying a version of the Parameter being retrieved, at least at time of writing this template
+            ### When performing a Fn::Join operation, apparently the resulting string doesn't have to be escaped with quotes - it's already output with the necessary handling?
+            # MasterUsername: '{{resolve:ssm:/production/2019/RDS/rdstestinstance/MASTER_USERNAME:1}}'
+            MasterUsername: !Join [ "", ["{{resolve:ssm:", !Ref SsmParameterPath, "/MASTER_USERNAME:1}}"]]
+            # MasterUserPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
+            MasterUserPassword: !Join [ "", ["{{resolve:ssm-secure:", !Ref SsmParameterPath, "/MASTER_PASSWORD:1}}"]]
             MultiAZ: false
             Port: 5432
             PubliclyAccessible: true

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -1,0 +1,59 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+
+AvailabilityZone:
+    Description: The AZ in which the RDS instance is deployed
+    Type: String
+    Default: us-west-2a
+
+SecurityGroup:
+    Description: Select the Security Group to use for this RDS instance
+    Type: AWS::EC2::SecurityGroup::Id
+
+SubnetGroup:
+    Description: Choose the subnet to which this RDS instance should be deployed
+    Type: AWS::RDS::DBSubnetGroup
+
+## Instance-specific parameters
+
+InstanceName:
+    Description: The name by which the DB instance is labelled in the RDS console
+    Type: String
+
+InstanceSize:
+    Description: The instance class (size) for this RDS instance
+    Type: String
+    Default: db.t2.micro
+
+InstanceStorage:
+    Description: The amount of storage in GB allocated to the RDS instance
+    Type: String
+
+## Database-specific parameters
+
+DatabaseName:
+    Description: The name of the primary database on this instance
+    Type: String
+
+Resources:
+
+    PostgresRDS:
+        Type: "AWS::RDS::DBInstance"
+        Properties:
+            AllocatedStorage: !Ref InstanceStorage
+            AvailabilityZone: !Ref AvailabilityZone
+            DBInstanceClass: !Ref InstanceSize
+            DBInstanceIdentifier: !Ref InstanceName
+            DBName: !Ref DatabaseName
+            DBSubnetGroupName: !Ref SubnetGroup
+            Engine: postgres
+            MasterUsername: mydatahack #todo
+            MasterUserPassword: mydatahackrocks #todo
+            MultiAZ: false
+            Port: 5432
+            PubliclyAccessible: true
+            Tags:
+                - Key: Name
+                  Value: !Ref InstanceName
+            VPCSecurityGroups:
+                - !Ref SecurityGroup

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -1,7 +1,9 @@
 Description: >
 
-    This template creates an RDS instance 
-
+    This template creates an RDS instance with a single Database and a master username + password.
+    It does not initialize that database with data (e.g. from backup), nor create a database-specific, lesser-privileged
+    user to expose to upstream applications.
+    Relevant to the HackOregon Civic Platform projects, this does not add the PostGIS extension to the database.
 
 Parameters:
 
@@ -34,29 +36,14 @@ Parameters:
         Type: String
         ConstraintDescription: must be between 5 and 1024 GB.
 
-    MasterUsername:
-        Description: The database admin account username
-        Type: String
-        ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
-        Default: dummyusername1
-
-    MasterPassword:
-        Description: The database admin account password
-        Type: String
-        # Type: SecureString # Works around error "SSM Secure reference is not supported in [AWS::CloudFormation::Stack/Properties/Parameters/MasterPassword]"
-        ConstraintDescription: must contain only alphanumeric characters.
-        Default: dummypassword2
-
-    ## SSM path-specific parameters
-
     SsmParameterPath:
         Description: The path in the SSM Parameter Store in which the RDS creds are stored
         Type: String
 
-    PasswordParamVersion: 
-        Description: The specific version of the SSM Parameter Store parameter to retrieve - all usage of {{resolve}} require this at time of writing this template
-        Type: String
-        Default: 1
+    # SsmParamVersion: 
+    #     Description: The specific version of the SSM Parameter Store parameter to retrieve - all usage of {{resolve}} require explicit versioning at time of writing this template
+    #     Type: String
+    #     Default: 1
 
     ## Database-specific parameters
 

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -27,6 +27,17 @@ Parameters:
     InstanceStorage:
         Description: The amount of storage in GB allocated to the RDS instance
         Type: String
+        ConstraintDescription: must be between 5 and 1024 GB.
+
+    # MasterUsername:
+    #     Description: The database admin account username
+    #     Type: String
+    #     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+
+    # MasterPassword:
+    #     Description: The database admin account password
+    #     Type: String
+    #     ConstraintDescription: must contain only alphanumeric characters.
 
     ## Database-specific parameters
 
@@ -37,17 +48,20 @@ Parameters:
 Resources:
 
     PostgresRDS:
-        Type: "AWS::RDS::DBInstance"
+        Type: AWS::RDS::DBInstance
         Properties:
+            AllowMajorVersionUpgrade: False
+            AutoMinorVersionUpgrade: True
             AllocatedStorage: !Ref InstanceStorage
+            StorageType: gp2
             AvailabilityZone: !Ref AvailabilityZone
             DBInstanceClass: !Ref InstanceSize
             DBInstanceIdentifier: !Ref InstanceName
             DBName: !Ref DatabaseName
             DBSubnetGroupName: !Ref SubnetGroupName
             Engine: postgres
-            MasterUsername: mydatahack #todo
-            MasterUserPassword: mydatahackrocks #todo
+            MasterUsername: dummyuser #todo
+            MasterUserPassword: dummypassword #todo
             MultiAZ: false
             Port: 5432
             PubliclyAccessible: true

--- a/database/rds-postgres.yaml
+++ b/database/rds-postgres.yaml
@@ -1,4 +1,3 @@
-AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
 
     AvailabilityZone:
@@ -10,9 +9,9 @@ Parameters:
         Description: Select the Security Group to use for this RDS instance
         Type: AWS::EC2::SecurityGroup::Id
 
-    SubnetGroup:
-        Description: Choose the subnet to which this RDS instance should be deployed
-        Type: AWS::RDS::DBSubnetGroup
+    SubnetGroupName:
+        Description: The Subnet Group(s) to which this RDS instance should be deployed
+        Type: String
 
     ## Instance-specific parameters
 
@@ -45,7 +44,7 @@ Resources:
             DBInstanceClass: !Ref InstanceSize
             DBInstanceIdentifier: !Ref InstanceName
             DBName: !Ref DatabaseName
-            DBSubnetGroupName: !Ref SubnetGroup
+            DBSubnetGroupName: !Ref SubnetGroupName
             Engine: postgres
             MasterUsername: mydatahack #todo
             MasterUserPassword: mydatahackrocks #todo

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -36,8 +36,10 @@ Parameters:
 
     ECSAMI:
         Description: ECS-Optimized AMI ID
-        Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-        Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+        #### Temporary - civic-devops-282 ###
+        # Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+        Type: String
+        # Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
 
 Resources:
 

--- a/infrastructure/security-groups.yaml
+++ b/infrastructure/security-groups.yaml
@@ -53,6 +53,7 @@ Resources:
               - Key: Name
                 Value: !Sub ${EnvironmentName}-ECS-Hosts
 
+  # This security group is meant for production-protected databases.
   # This security group defines who/where is allowed to access the DB hosts directly.
   DBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -67,6 +68,22 @@ Resources:
         Tags:
             - Key: Name
               Value: !Sub ${EnvironmentName}-DB-Hosts
+
+  # This security group is meant for developer-accessible databases.
+  DBPublicSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+        VpcId: !Ref VPC
+        GroupDescription: Access to DB instances from anywhere on the Internet
+        SecurityGroupIngress:
+              # Allow access from anywhere to the DB instances on port 5432
+              - CidrIp: 0.0.0.0/0
+                IpProtocol: TCP
+                FromPort: 0
+                ToPort: 5432
+        Tags:
+            - Key: Name
+              Value: !Sub ${EnvironmentName}-DB-Public-Hosts
 
   # This security group defines who/where is allowed to access load balancer
   LoadBalancerSecurityGroup:
@@ -116,7 +133,7 @@ Resources:
 Outputs:
 
     BastionHostSecurityGroup:
-        Description: A reference to the security group for load balancers
+        Description: A reference to the security group for bastion hosts
         Value: !Ref BastionHostSecurityGroup
 
     ECSHostSecurityGroup:
@@ -124,13 +141,17 @@ Outputs:
         Value: !Ref ECSHostSecurityGroup
 
     DBSecurityGroup:
-        Description: A reference to the security group for load balancers
+        Description: A reference to the security group for protected DB instances
         Value: !Ref DBSecurityGroup
+
+    DBPublicSecurityGroup:
+        Description: A reference to the security group for public DB instances
+        Value: !Ref DBPublicSecurityGroup
 
     LoadBalancerSecurityGroup:
         Description: A reference to the security group for load balancers
         Value: !Ref LoadBalancerSecurityGroup
 
     ECSTaskSecurityGroup:
-        Description: A reference to the security group for ECS hosts
+        Description: A reference to the security group for ECS tasks
         Value: !Ref ECSTaskSecurityGroup

--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -102,6 +102,19 @@ Resources:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Private Subnet (AZ2)
 
+    PublicDBSubnetGroup:
+        Type: AWS::RDS::DBSubnetGroup
+        Properties:
+            DBSubnetGroupDescription: Subnet Group for publicly-exposed RDS instances
+            DBSubnetGroupName: !Sub ${EnvironmentName}-PublicDBSubnetGroup
+            SubnetIds:
+                - !Ref PublicSubnet1
+                - !Ref PublicSubnet2
+            Tags:
+                -
+                Key: Name
+                Value: !Sub ${EnvironmentName} Public DB Subnet Group
+
     NatGateway1EIP:
         Type: AWS::EC2::EIP
         DependsOn: InternetGatewayAttachment
@@ -225,3 +238,7 @@ Outputs:
     PrivateSubnet2:
         Description: A reference to the private subnet in the 2nd Availability Zone
         Value: !Ref PrivateSubnet2
+
+    PublicDBSubnetGroup:
+        Description: A reference to the public subnet group for databases
+        Value: !Ref PublicDBSubnetGroup

--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -111,9 +111,8 @@ Resources:
                 - !Ref PublicSubnet1
                 - !Ref PublicSubnet2
             Tags:
-                -
-                Key: Name
-                Value: !Sub ${EnvironmentName} Public DB Subnet Group
+                - Key: Name
+                  Value: !Sub ${EnvironmentName} Public DB Subnet Group
 
     NatGateway1EIP:
         Type: AWS::EC2::EIP

--- a/master.yaml
+++ b/master.yaml
@@ -141,11 +141,11 @@ Resources:
     RDSTestInstance:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/databases/rds-postgres.yaml
+            TemplateURL: https://hacko-infrastructure-cfn.s3-us-west-2.amazonaws.com/database/rds-postgres.yaml ## TODO: figure out why the typical URL gets us Access Denied on all attempts
             Parameters:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBSecurityGroup
-                SubnetGroup: !GetAtt VPC.Outputs.PublicDBSubnetGroup
+                SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
                 InstanceName: RDSTestInstance
                 InstanceSize: db.t2.micro
                 InstanceStorage: 20

--- a/master.yaml
+++ b/master.yaml
@@ -139,7 +139,7 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance2:
+    RDSTestInstance:
         Type: AWS::CloudFormation::Stack
         Properties:
             TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
@@ -147,12 +147,12 @@ Resources:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstest20191015
-                InstanceSize: db.t2.micro
-                InstanceStorage: 20
-                DatabaseName: RDSTestDb1
-                # MasterUsername: '{{resolve:ssm:parampath/paramname1:1}}'
-                # MasterPassword: "{{resolve:ssm-secure:parampath/paramname2:1}}"
+                InstanceName: rdstestinstance
+                InstanceSize: db.t2.small
+                InstanceStorage: 50
+                DatabaseName: RDSTestDbMike
+                # MasterUsername: '{{resolve:ssm:/production/2019/RDS/rdstestinstance/MASTER_USERNAME:1}}'
+                # MasterPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
 
 ##### EC2 instances #####
 

--- a/master.yaml
+++ b/master.yaml
@@ -136,6 +136,21 @@ Resources:
                 HostedZoneId: !GetAtt ALB.Outputs.CanonicalHostedZoneId
                 DNSName: !GetAtt ALB.Outputs.PublicAlbDnsName
 
+##### Databases #####
+
+    RDSTestInstance:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/databases/rds-postgres.yaml
+            Parameters:
+                AvailabilityZone: us-west-2a
+                SecurityGroup: !GetAtt SecurityGroups.Outputs.DBSecurityGroup
+                SubnetGroup: !GetAtt VPC.Outputs.PublicDBSubnetGroup
+                InstanceName: RDSTestInstance
+                InstanceSize: db.t2.micro
+                InstanceStorage: 20
+                DatabaseName: RDSTestDb1
+
 ##### EC2 instances #####
 
     BastionHost:

--- a/master.yaml
+++ b/master.yaml
@@ -139,7 +139,7 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance2:
+    RDSTestInstance4:
         Type: AWS::CloudFormation::Stack
         Properties:
             TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
@@ -147,12 +147,12 @@ Resources:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstestinstance2
-                InstanceSize: db.t2.small
-                InstanceStorage: 50
+                InstanceName: rdstestinstance4
+                InstanceSize: db.t2.micro
+                InstanceStorage: 20
                 DatabaseName: RDSTestDbMike
-                MasterUsername: '{{resolve:ssm:/production/2019/RDS/rdstestinstance/MASTER_USERNAME:1}}'
-                # MasterPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
+                SsmParameterPath: /production/2019/RDS/rdstestinstance
+                PasswordParamVersion: 1
 
 ##### EC2 instances #####
 

--- a/master.yaml
+++ b/master.yaml
@@ -139,19 +139,19 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance:
-        Type: AWS::CloudFormation::Stack
-        Properties:
-            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
-            Parameters:
-                AvailabilityZone: us-west-2a
-                SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
-                SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstestinstance
-                InstanceSize: db.t2.micro
-                InstanceStorage: 20
-                SsmParameterPath: /production/2019/RDS/rdstestinstance
-                DatabaseName: RDSTestDbMike
+    # RDSTestInstance:
+    #     Type: AWS::CloudFormation::Stack
+    #     Properties:
+    #         TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
+    #         Parameters:
+    #             AvailabilityZone: us-west-2a
+    #             SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
+    #             SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
+    #             InstanceName: rdstestinstance
+    #             InstanceSize: db.t2.micro
+    #             InstanceStorage: 20
+    #             SsmParameterPath: /production/2019/RDS/rdstestinstance
+    #             DatabaseName: RDSTestDbMike
 
 ##### EC2 instances #####
 

--- a/master.yaml
+++ b/master.yaml
@@ -139,7 +139,7 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance4:
+    RDSTestInstance:
         Type: AWS::CloudFormation::Stack
         Properties:
             TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
@@ -147,12 +147,11 @@ Resources:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstestinstance4
+                InstanceName: rdstestinstance
                 InstanceSize: db.t2.micro
                 InstanceStorage: 20
-                DatabaseName: RDSTestDbMike
                 SsmParameterPath: /production/2019/RDS/rdstestinstance
-                PasswordParamVersion: 1
+                DatabaseName: RDSTestDbMike
 
 ##### EC2 instances #####
 

--- a/master.yaml
+++ b/master.yaml
@@ -139,7 +139,7 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance:
+    RDSTestInstance2:
         Type: AWS::CloudFormation::Stack
         Properties:
             TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
@@ -147,11 +147,11 @@ Resources:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstestinstance
+                InstanceName: rdstestinstance2
                 InstanceSize: db.t2.small
                 InstanceStorage: 50
                 DatabaseName: RDSTestDbMike
-                # MasterUsername: '{{resolve:ssm:/production/2019/RDS/rdstestinstance/MASTER_USERNAME:1}}'
+                MasterUsername: '{{resolve:ssm:/production/2019/RDS/rdstestinstance/MASTER_USERNAME:1}}'
                 # MasterPassword: "{{resolve:ssm-secure:/production/2019/RDS/rdstestinstance/MASTER_PASSWORD:1}}"
 
 ##### EC2 instances #####

--- a/master.yaml
+++ b/master.yaml
@@ -141,12 +141,12 @@ Resources:
     RDSTestInstance:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://hacko-infrastructure-cfn.s3-us-west-2.amazonaws.com/database/rds-postgres.yaml ## TODO: figure out why the typical URL gets us Access Denied on all attempts
+            TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
             Parameters:
                 AvailabilityZone: us-west-2a
-                SecurityGroup: !GetAtt SecurityGroups.Outputs.DBSecurityGroup
+                SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: RDSTestInstance
+                InstanceName: rdstestinstance
                 InstanceSize: db.t2.micro
                 InstanceStorage: 20
                 DatabaseName: RDSTestDb1

--- a/master.yaml
+++ b/master.yaml
@@ -75,6 +75,7 @@ Resources:
                 VPC: !GetAtt VPC.Outputs.VPC
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSHostSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
+                ECSAMI: ami-0f7bc74af1927e7c8 # TEMPORARY civic-devops-282
 
 #### DNS records ####
 
@@ -138,7 +139,7 @@ Resources:
 
 ##### Databases #####
 
-    RDSTestInstance:
+    RDSTestInstance2:
         Type: AWS::CloudFormation::Stack
         Properties:
             TemplateURL: https://s3-us-west-2.amazonaws.com/hacko-infrastructure-cfn/database/rds-postgres.yaml
@@ -146,10 +147,12 @@ Resources:
                 AvailabilityZone: us-west-2a
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.DBPublicSecurityGroup
                 SubnetGroupName: !GetAtt VPC.Outputs.PublicDBSubnetGroup
-                InstanceName: rdstestinstance
+                InstanceName: rdstest20191015
                 InstanceSize: db.t2.micro
                 InstanceStorage: 20
                 DatabaseName: RDSTestDb1
+                # MasterUsername: '{{resolve:ssm:parampath/paramname1:1}}'
+                # MasterPassword: "{{resolve:ssm-secure:parampath/paramname2:1}}"
 
 ##### EC2 instances #####
 


### PR DESCRIPTION
Addresses https://github.com/hackoregon/civic-devops/issues/283.

The primary output of this venture is CloudFormation template to create RDS instances from scratch.

Output:
- a single RDS instance of specified size and storage amount in one of any of the subnets specified in the subnet group
- a single database created in the instance, owned by the Master username

Benefits:
- allows re-sizing both the instance (e.g. db.t2.micro) and storage (e.g. 20 GiB) 
- can specify any Security group to enable either publicly-accessible database or a more restricted profile such as one that can only be accessed from other applications in the VPC
- no secrets (credentials) are hard-coded into the CloudFormation templates

Limitations:
- it appears that when changing Master username or password, the RDS instance must be migrated to a new instance (cannot be reconfigured in place).

Dependencies:
- requires use of SSM Parameter Store to hold `MASTER_USERNAME` and `MASTER_PASSWORD` credentials for use as the root-level creds for the RDS instance