### PR TITLE
Pin the latest working AMI to our cluster

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -36,8 +36,10 @@ Parameters:
 
     ECSAMI:
         Description: ECS-Optimized AMI ID
-        Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-        Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
+        #### Temporary - civic-devops-282 ###
+        # Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+        Type: String
+        # Default: /aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id
 
 Resources:
 

--- a/master.yaml
+++ b/master.yaml
@@ -75,6 +75,7 @@ Resources:
                 VPC: !GetAtt VPC.Outputs.VPC
                 SecurityGroup: !GetAtt SecurityGroups.Outputs.ECSHostSecurityGroup
                 Subnets: !GetAtt VPC.Outputs.PrivateSubnets
+                ECSAMI: ami-0f7bc74af1927e7c8 # TEMPORARY civic-devops-282
 
 #### DNS records ####
 


### PR DESCRIPTION
Resolves https://github.com/hackoregon/civic-devops/issues/282 (or at least works around it temporarily, until we either jettison EC2 hosts entirely and fully migrate to Fargate, or we figure out what the incompatibility in our EC2 configuration is with the latest AMI)