### PR TITLE
Tagging resources

### DIFF
--- a/fargate-services/2017-fargate-api.yaml
+++ b/fargate-services/2017-fargate-api.yaml
@@ -132,6 +132,11 @@ Resources:
                 - ContainerName: !Ref ProjectName
                   ContainerPort: !Ref ContainerPort
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
@@ -144,6 +149,11 @@ Resources:
               - FARGATE
             ExecutionRoleArn: !Ref ECSTaskExecutionRole
             TaskRoleArn: !Ref TaskRole
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
             ContainerDefinitions:
                 - Name: !Ref ProjectName
                   Essential: true

--- a/fargate-services/2019-fargate-api.yaml
+++ b/fargate-services/2019-fargate-api.yaml
@@ -3,7 +3,7 @@
 
 Description: >
     ECS Service definition for all HackOregon 2019 APIs
-Parameters: 
+Parameters:
 
 ## Miscellaneous configuration parameters
 
@@ -37,7 +37,7 @@ Parameters:
         Description: The host path to register with the Application Load Balancer
         Type: String
 
-    Path: 
+    Path:
         Description: The path to register with the Application Load Balancer
         Type: String
 
@@ -55,7 +55,7 @@ Parameters:
         Description: Please provide the ECS Cluster ID that this service should run on
         Type: String
 
-    DesiredCount: 
+    DesiredCount:
         Default: 0 # Allows us to deploy the service even if there's no container image to launch
         Description: How many instances of this task should we run across our cluster?
         Type: Number
@@ -97,10 +97,10 @@ Parameters:
 Resources:
 
 ## This service definition introduces NetworkConfiguration and lacks PlacementStrategies and Role
-    Service: 
+    Service:
         Type: AWS::ECS::Service
         DependsOn: ListenerRule
-        Properties: 
+        Properties:
             Cluster: !Ref Cluster
             DeploymentConfiguration:
                 MaximumPercent: 200
@@ -116,10 +116,15 @@ Resources:
                       - !Select [ 0, !Ref Subnets ]
                       - !Select [ 1, !Ref Subnets ]
             TaskDefinition: !Ref TaskDefinition
-            LoadBalancers: 
+            LoadBalancers:
                 - ContainerName: !Ref ProjectName
                   ContainerPort: !Ref ContainerPort
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
@@ -132,6 +137,11 @@ Resources:
               - FARGATE
             ExecutionRoleArn: !Ref ECSTaskExecutionRole
             TaskRoleArn: !Ref TaskRole
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
             ContainerDefinitions:
                 - Name: !Ref ProjectName
                   Essential: true
@@ -164,9 +174,9 @@ Resources:
 
     CloudWatchLogsGroup:
         Type: AWS::Logs::LogGroup
-        Properties: 
+        Properties:
             LogGroupName: !Ref AWS::StackName
-            RetentionInDays: 365  
+            RetentionInDays: 365
 
     TargetGroup:
         Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -175,7 +185,7 @@ Resources:
             Port: 80
             Protocol: HTTP
             TargetType: ip
-            Matcher: 
+            Matcher:
                 # HttpCode: 200-299
                 HttpCode: 200-299,404 # Civic Devops issue #254
             HealthCheckIntervalSeconds: 10
@@ -194,7 +204,7 @@ Resources:
                   Values:
                     - !Ref Host
                 - Field: path-pattern
-                  Values: 
+                  Values:
                     - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
@@ -221,8 +231,8 @@ Resources:
     # This IAM Role grants the Fargate-based service access to register/unregister with the
     # Application Load Balancer (ALB). It is based on the default documented here:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
-    # 
-    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies 
+    #
+    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies
     # such as allowing SSM access.
     TaskRole:
         Type: AWS::IAM::Role
@@ -259,7 +269,7 @@ Resources:
                         }]
                     }
                 - PolicyName: ssm-access
-                  PolicyDocument: 
+                  PolicyDocument:
                     {
                         "Version": "2012-10-17",
                         "Statement": [

--- a/fargate-services/fargate-endpoints-catalog.yaml
+++ b/fargate-services/fargate-endpoints-catalog.yaml
@@ -46,7 +46,7 @@ Parameters:
         Description: The host path to register with the Application Load Balancer
         Type: String
 
-    Path: 
+    Path:
         Description: The path to register with the Application Load Balancer
         Type: String
 
@@ -68,7 +68,7 @@ Parameters:
         Description: Please provide the ECS Cluster ID that this service should run on
         Type: String
 
-    DesiredCount: 
+    DesiredCount:
         Default: 0 # Allows us to deploy the service even if there's no container image to launch
         Description: How many instances of this task should we run across our cluster?
         Type: Number
@@ -110,10 +110,10 @@ Parameters:
 Resources:
 
 ## This service definition introduces NetworkConfiguration and lacks PlacementStrategies and Role
-    Service: 
+    Service:
         Type: AWS::ECS::Service
         DependsOn: ListenerRule
-        Properties: 
+        Properties:
             Cluster: !Ref Cluster
             DeploymentConfiguration:
                 MaximumPercent: 200
@@ -129,10 +129,15 @@ Resources:
                       - !Select [ 0, !Ref Subnets ]
                       - !Select [ 1, !Ref Subnets ]
             TaskDefinition: !Ref TaskDefinition
-            LoadBalancers: 
+            LoadBalancers:
                 - ContainerName: !Ref ProjectName
                   ContainerPort: !Ref ContainerPort
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
@@ -145,6 +150,11 @@ Resources:
               - FARGATE
             ExecutionRoleArn: !Ref ECSTaskExecutionRole
             TaskRoleArn: !Ref TaskRole
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
             ContainerDefinitions:
                 - Name: !Ref ProjectName
                   Essential: true
@@ -165,9 +175,9 @@ Resources:
 
     CloudWatchLogsGroup:
         Type: AWS::Logs::LogGroup
-        Properties: 
+        Properties:
             LogGroupName: !Ref AWS::StackName
-            RetentionInDays: 365  
+            RetentionInDays: 365
 
     TargetGroup:
         Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -176,7 +186,7 @@ Resources:
             Port: 80
             Protocol: HTTP
             TargetType: ip
-            Matcher: 
+            Matcher:
                 # HttpCode: 200-299
                 HttpCode: 200-299,404 # Civic Devops issue #254
             HealthCheckIntervalSeconds: 10
@@ -195,7 +205,7 @@ Resources:
                   Values:
                     - !Ref Host
                 - Field: path-pattern
-                  Values: 
+                  Values:
                     - !Ref Path
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
@@ -258,8 +268,8 @@ Resources:
     # This IAM Role grants the Fargate-based service access to register/unregister with the
     # Application Load Balancer (ALB). It is based on the default documented here:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
-    # 
-    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies 
+    #
+    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies
     # such as allowing SSM access.
     TaskRole:
         Type: AWS::IAM::Role
@@ -296,7 +306,7 @@ Resources:
                         }]
                     }
                 - PolicyName: ssm-access
-                  PolicyDocument: 
+                  PolicyDocument:
                     {
                         "Version": "2012-10-17",
                         "Statement": [

--- a/fargate-services/fargate-frontend.yaml
+++ b/fargate-services/fargate-frontend.yaml
@@ -101,10 +101,10 @@ Parameters:
 Resources:
 
 ## This service definition introduces NetworkConfiguration and lacks PlacementStrategies and Role
-    Service: 
+    Service:
         Type: AWS::ECS::Service
         DependsOn: ListenerRule
-        Properties: 
+        Properties:
             Cluster: !Ref Cluster
             DeploymentConfiguration:
                 MaximumPercent: 200
@@ -120,10 +120,15 @@ Resources:
                       - !Select [ 0, !Ref Subnets ]
                       - !Select [ 1, !Ref Subnets ]
             TaskDefinition: !Ref TaskDefinition
-            LoadBalancers: 
+            LoadBalancers:
                 - ContainerName: !Ref ProjectName
                   ContainerPort: !Ref ContainerPort
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
@@ -136,6 +141,11 @@ Resources:
               - FARGATE
             ExecutionRoleArn: !Ref ECSTaskExecutionRole
             TaskRoleArn: !Ref TaskRole
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: !Ref ProjectName
             ContainerDefinitions:
                 - Name: !Ref ProjectName
                   Essential: true
@@ -229,8 +239,8 @@ Resources:
     # This IAM Role grants the Fargate-based service access to register/unregister with the
     # Application Load Balancer (ALB). It is based on the default documented here:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
-    # 
-    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies 
+    #
+    # It also has the side-effect of allowing other parts of the stack to attach other IAM policies
     # such as allowing SSM access.
     TaskRole:
         Type: AWS::IAM::Role

--- a/infrastructure/ec2-instance.yaml
+++ b/infrastructure/ec2-instance.yaml
@@ -82,8 +82,11 @@ Resources:
       SubnetId: !Ref Subnet
       ImageId: !FindInMap [HackoImageMap, !Ref AmiName, AMI]
       Tags:
-      -
-        Key: Name
-        Value: !Sub ${EnvironmentName} !Sub ${ServerName}
-        Key: Environment
-        Value: !Ref EnvironmentName
+        - Key: Name
+          Value: !Sub ${EnvironmentName} !Sub ${ServerName}
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Account
+          Value: HackOregon
+        - Key: Project
+          Value: Admin

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -60,6 +60,12 @@ Resources:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} ECS host
                   PropagateAtLaunch: true
+                - Key: Account
+                  Value: HackOregon
+                  PropagateAtLaunch: true
+                - Key: Project
+                  Value: Admin
+                  PropagateAtLaunch: true
         CreationPolicy:
             ResourceSignal:
                 Timeout: PT15M
@@ -176,7 +182,7 @@ Resources:
                         }]
                     }
                 - PolicyName: ssm-access
-                  PolicyDocument: 
+                  PolicyDocument:
                     {
                         "Version": "2012-10-17",
                         "Statement": [
@@ -221,7 +227,7 @@ Resources:
             Roles:
                 - !Ref ECSRole
 
-    # This is a role which is used by the ECS service to perform ECS API actions on your 
+    # This is a role which is used by the ECS service to perform ECS API actions on your
     # behalf, such pulling container images from ECR, or storing container application
     # logs in CloudWatch.
     ECSTaskExecutionRole:

--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -45,6 +45,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Ref EnvironmentName
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     LoadBalancerListener:
         Type: AWS::ElasticLoadBalancingV2::Listener
@@ -70,8 +74,8 @@ Resources:
                   TargetGroupArn: !Ref DefaultTargetGroup
 
     # We define a default target group here, as this is a mandatory Parameter
-    # when creating an Application Load Balancer Listener. 
-    # However, this is not used - instead a target group is created per-service 
+    # when creating an Application Load Balancer Listener.
+    # However, this is not used - instead a target group is created per-service
     # in each service template (../services/*)
     DefaultTargetGroup:
         Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -110,6 +114,6 @@ Outputs:
     SslCertificate:
         Value:
             !If [ SslCertificate, True, False ]
-    
+
     CanonicalHostedZoneId:
         Value: !GetAtt LoadBalancer.CanonicalHostedZoneID

--- a/infrastructure/security-groups.yaml
+++ b/infrastructure/security-groups.yaml
@@ -19,7 +19,7 @@ Parameters:
 Resources:
 
 ## TODO: Refactor these security groups so that ECSHostSecurityGroup references
-## the "web server access" and "SSH access" that is defined as common, and then 
+## the "web server access" and "SSH access" that is defined as common, and then
 ## also point BastionHost and LoadBalancer at these common resources
 
   # This security group defines who/where is allowed to access the Bastion host directly.
@@ -37,6 +37,10 @@ Resources:
           Tags:
               - Key: Name
                 Value: !Sub ${EnvironmentName}-Bastion-Hosts
+              - Key: Account
+                Value: HackOregon
+              - Key: Project
+                Value: Admin
 
   # This security group defines who/where is allowed to access the ECS hosts directly.
   ECSHostSecurityGroup:
@@ -52,6 +56,10 @@ Resources:
           Tags:
               - Key: Name
                 Value: !Sub ${EnvironmentName}-ECS-Hosts
+              - Key: Account
+                Value: HackOregon
+              - Key: Project
+                Value: Admin
 
   # This security group is meant for production-protected databases.
   # This security group defines who/where is allowed to access the DB hosts directly.
@@ -68,6 +76,10 @@ Resources:
         Tags:
             - Key: Name
               Value: !Sub ${EnvironmentName}-DB-Hosts
+            - Key: Account
+              Value: HackOregon
+            - Key: Project
+              Value: Admin
 
   # This security group is meant for developer-accessible databases.
   DBPublicSecurityGroup:
@@ -84,6 +96,10 @@ Resources:
         Tags:
             - Key: Name
               Value: !Sub ${EnvironmentName}-DB-Public-Hosts
+            - Key: Account
+              Value: HackOregon
+            - Key: Project
+              Value: Admin
 
   # This security group defines who/where is allowed to access load balancer
   LoadBalancerSecurityGroup:
@@ -104,6 +120,10 @@ Resources:
         Tags:
             - Key: Name
               Value: !Sub ${EnvironmentName}-LoadBalancers
+            - Key: Account
+              Value: HackOregon
+            - Key: Project
+              Value: Admin
 
   # This security group defines who/where is allowed to access the Tasks running in ECS
   ECSTaskSecurityGroup:
@@ -129,6 +149,10 @@ Resources:
           Tags:
               - Key: Name
                 Value: !Sub ${EnvironmentName}-ECS-Hosts
+              - Key: Account
+                Value: HackOregon
+              - Key: Project
+                Value: Admin
 
 Outputs:
 

--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -44,6 +44,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Ref EnvironmentName
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     InternetGateway:
         Type: AWS::EC2::InternetGateway
@@ -51,6 +55,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Ref EnvironmentName
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     InternetGatewayAttachment:
         Type: AWS::EC2::VPCGatewayAttachment
@@ -68,6 +76,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Public Subnet (AZ1)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     PublicSubnet2:
         Type: AWS::EC2::Subnet
@@ -79,6 +91,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Public Subnet (AZ2)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     PrivateSubnet1:
         Type: AWS::EC2::Subnet
@@ -90,6 +106,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Private Subnet (AZ1)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     PrivateSubnet2:
         Type: AWS::EC2::Subnet
@@ -101,6 +121,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Private Subnet (AZ2)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     PublicDBSubnetGroup:
         Type: AWS::RDS::DBSubnetGroup
@@ -113,6 +137,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Public DB Subnet Group
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     NatGateway1EIP:
         Type: AWS::EC2::EIP
@@ -145,6 +173,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Public Routes
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     DefaultPublicRoute:
         Type: AWS::EC2::Route
@@ -173,6 +205,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Private Routes (AZ1)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     DefaultPrivateRoute1:
         Type: AWS::EC2::Route
@@ -194,6 +230,10 @@ Resources:
             Tags:
                 - Key: Name
                   Value: !Sub ${EnvironmentName} Private Routes (AZ2)
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: Admin
 
     DefaultPrivateRoute2:
         Type: AWS::EC2::Route

--- a/services/homeless-service/service.yaml
+++ b/services/homeless-service/service.yaml
@@ -36,7 +36,7 @@ Parameters:
     ProjSettingsDir:
         Description: the relative directory path where we keep the app config
         Type: String
-    
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -67,11 +67,21 @@ Resources:
                 - ContainerName: "homeless-service"
                   ContainerPort: 8000
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: homeless-service
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
         Properties:
             Family: homeless-service
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: homeless-service
             ContainerDefinitions:
                 - Name: homeless-service
                   Essential: true

--- a/services/housing-affordability-service/service.yaml
+++ b/services/housing-affordability-service/service.yaml
@@ -55,11 +55,20 @@ Resources:
                 - ContainerName: "housing-affordability-service"
                   ContainerPort: 8000
                   TargetGroupArn: !Ref TargetGroup
-
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: housing-affordability-service
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
         Properties:
             Family: housing-affordability-service
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: housing-affordability-service
             ContainerDefinitions:
                 - Name: housing-affordability-service
                   Essential: true
@@ -106,7 +115,7 @@ Resources:
                 - Field: path-pattern
                   Values:
                     - !Ref Path
- 
+
             Actions:
                 - TargetGroupArn: !Ref TargetGroup
                   Type: forward

--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -36,7 +36,7 @@ Parameters:
     ProjSettingsDir:
         Description: the relative directory path where we keep the app config
         Type: String
-    
+
     Host:
         Description: The host path to register with the Application Load Balancer
         Type: String
@@ -67,11 +67,21 @@ Resources:
                 - ContainerName: "transport-service"
                   ContainerPort: 8000
                   TargetGroupArn: !Ref TargetGroup
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: transport-service
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
         Properties:
             Family: transport-service
+            Tags:
+                - Key: Account
+                  Value: HackOregon
+                - Key: Project
+                  Value: transport-service
             ContainerDefinitions:
                 - Name: transport-service
                   Essential: true


### PR DESCRIPTION
Closes #101 

Tagging by account and project. All resources in this repo are for the HackOregon account, but there are other "accounts" in our AWS account.

Notably there are some resources that aren't provisioned via CloudFormation (such as RDS instances), those will need to be tagged manually.

I also deviated from the tagging plan a bit, but we'll still be able to constructs reports the same way, just with different queries.