### PR TITLE
Decrease health check interval to 10 minutes

### DIFF
--- a/fargate-services/2017-fargate-api.yaml
+++ b/fargate-services/2017-fargate-api.yaml
@@ -202,7 +202,7 @@ Resources:
             TargetType: ip
             Matcher:
                 HttpCode: 200-299
-            HealthCheckIntervalSeconds: 10
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: !Ref HealthCheckPathName
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 5

--- a/fargate-services/2019-fargate-api.yaml
+++ b/fargate-services/2019-fargate-api.yaml
@@ -188,7 +188,7 @@ Resources:
             Matcher:
                 # HttpCode: 200-299
                 HttpCode: 200-299,404 # Civic Devops issue #254
-            HealthCheckIntervalSeconds: 10
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: !Ref HealthCheckPathName
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 5

--- a/fargate-services/fargate-endpoints-catalog.yaml
+++ b/fargate-services/fargate-endpoints-catalog.yaml
@@ -189,7 +189,7 @@ Resources:
             Matcher:
                 # HttpCode: 200-299
                 HttpCode: 200-299,404 # Civic Devops issue #254
-            HealthCheckIntervalSeconds: 10
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: !Ref HealthCheckPathName
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 5

--- a/fargate-services/fargate-frontend.yaml
+++ b/fargate-services/fargate-frontend.yaml
@@ -179,7 +179,7 @@ Resources:
             TargetType: ip
             Matcher:
                 HttpCode: 200-299
-            HealthCheckIntervalSeconds: 45
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: !Ref HealthCheckPathName
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40

--- a/services/homeless-service/service.yaml
+++ b/services/homeless-service/service.yaml
@@ -116,7 +116,7 @@ Resources:
             Protocol: HTTP
             Matcher:
                 HttpCode: 200-299
-            HealthCheckIntervalSeconds: 45
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: /homeless/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40

--- a/services/housing-affordability-service/service.yaml
+++ b/services/housing-affordability-service/service.yaml
@@ -96,7 +96,7 @@ Resources:
             Protocol: HTTP
             Matcher:
                 HttpCode: 200-299
-            HealthCheckIntervalSeconds: 45
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: /housing-affordability/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40

--- a/services/transport-service/service.yaml
+++ b/services/transport-service/service.yaml
@@ -116,7 +116,7 @@ Resources:
             Protocol: HTTP
             Matcher:
                 HttpCode: 200-299
-            HealthCheckIntervalSeconds: 45
+            HealthCheckIntervalSeconds: 600
             HealthCheckPath: /transport/
             HealthCheckProtocol: HTTP
             HealthCheckTimeoutSeconds: 40


### PR DESCRIPTION
We aren't running mission critical services over here. Heartbeating every 10 seconds has a nontrivial network cost.

Once the tags changes have sat in prod a bit, I'd like to roll this out.

This change is data-informed by the VPC flow logs showing how much traffic is a result of the ECS cluster. Of course we expect a lot of traffic from the cluster since that's where our services live, but the day over day uniformity of the traffic suggests health checks alone may be a sizable amount of the total traffic.